### PR TITLE
fix: reverse psm exchange rate logic

### DIFF
--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -45,6 +45,11 @@ interface IPSMcore {
 
     function depositPsm(Id id, uint256 amount) external;
 
+    /**
+     * This determines the rate of how much the user will receive for the amount of asset they want to deposit.
+     * for example, if the rate is 1.5, then the user will need to deposit 1.5 token to get 1 CT and DS.
+     * @param id the id of the PSM
+     */
     function exchangeRate(Id id) external view returns (uint256 rates);
 
     function previewDepositPsm(

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -115,19 +115,19 @@ library MathHelper {
         uint256 amount,
         uint256 exchangeRate
     ) external pure returns (uint256 _amount) {
-        _amount = (amount * exchangeRate) / 1e18;
+        _amount = (amount * 1e18) / exchangeRate;
     }
 
     /**
      * @dev caclulcate how much ra user will receive when redeeming with x amount of ds based on the current exchange rate
      * @param amount the amount of ds user want to redeem
-     * @param exchangeRate the current exchange rate between RA:(CT+DS) 
+     * @param exchangeRate the current exchange rate between RA:(CT+DS)
      */
     function calculateRedeemAmountWithExchangeRate(
         uint256 amount,
         uint256 exchangeRate
     ) external pure returns (uint256 _amount) {
-        _amount = (amount * 1e18) / exchangeRate;
+        _amount = (amount * exchangeRate) / 1e18;
     }
 
     // TODO : unit test this, just move here from psm

--- a/test/lib/MathHelper.ts
+++ b/test/lib/MathHelper.ts
@@ -127,148 +127,150 @@ describe("Math Helper", function () {
       expect(result).to.equal(parseEther("10"));
     });
 
-    it("should calcuate psm deposit amount with exchange rates", async function () {
-      const contract = await loadFixture(deployMathHelper);
+    describe("PSM Math", function () {
+      it("should calcuate psm deposit amount with exchange rates", async function () {
+        const contract = await loadFixture(deployMathHelper);
 
-      const amount = parseEther("10");
-      const rate = parseEther("1");
+        const amount = parseEther("10");
+        const rate = parseEther("1");
 
-      const result = await contract.read.calculateDepositAmountWithExchangeRate(
-        [amount, rate]
-      );
+        const result =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate,
+          ]);
 
-      expect(result).to.equal(parseEther("10"));
+        expect(result).to.equal(parseEther("10"));
 
-      const rate2 = parseEther("2");
+        const rate2 = parseEther("2");
 
-      const result2 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate2,
-        ]);
+        const result2 =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate2,
+          ]);
 
-      expect(result2).to.equal(parseEther("20"));
+        expect(result2).to.equal(parseEther("5"));
 
-      const rate3 = parseEther("0.5");
+        const rate3 = parseEther("0.5");
 
-      const result3 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate3,
-        ]);
+        const result3 =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate3,
+          ]);
 
-      expect(result3).to.equal(parseEther("5"));
+        expect(result3).to.equal(parseEther("20"));
 
-      const rate4 = parseEther("0.6");
+        const result6 =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            parseEther("0.5"),
+            rate3,
+          ]);
 
-      const result4 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate4,
-        ]);
+        expect(result6).to.equal(parseEther("1"));
+      });
 
-      expect(result4).to.equal(parseEther("6"));
+      it("should calculate psm redeem amount with exchange rates", async function () {
+        const contract = await loadFixture(deployMathHelper);
 
-      const result5 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          parseEther("2"),
-          rate4,
-        ]);
+        const amount = parseEther("10");
+        const rate = parseEther("1");
 
-      expect(result5).to.equal(parseEther("1.2"));
+        const result =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            amount,
+            rate,
+          ]);
 
-      const result6 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          parseEther("0.5"),
-          rate3,
-        ]);
+        expect(result).to.equal(parseEther("10"));
 
-      expect(result6).to.equal(parseEther("0.25"));
-    });
+        const rate2 = parseEther("2");
 
-    it("should calculate psm redeem amount with exchange rates", async function () {
-      const contract = await loadFixture(deployMathHelper);
+        const result2 =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            amount,
+            rate2,
+          ]);
 
-      const amount = parseEther("10");
-      const rate = parseEther("1");
+        expect(result2).to.equal(parseEther("20"));
 
-      const result = await contract.read.calculateRedeemAmountWithExchangeRate([
-        amount,
-        rate,
-      ]);
+        const rate3 = parseEther("0.5");
 
-      expect(result).to.equal(parseEther("10"));
+        const result3 =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            amount,
+            rate3,
+          ]);
 
-      const rate2 = parseEther("2");
+        expect(result3).to.equal(parseEther("5"));
+      });
 
-      const result2 = await contract.read.calculateRedeemAmountWithExchangeRate(
-        [amount, rate2]
-      );
+      it("should balance when psm deposit and redeem using exchange rate", async function () {
+        const contract = await loadFixture(deployMathHelper);
 
-      expect(result2).to.equal(parseEther("5"));
+        const amount = parseEther("10");
+        const rate = parseEther("1");
 
-      const rate3 = parseEther("0.5");
+        const deposit =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate,
+          ]);
 
-      const result3 = await contract.read.calculateRedeemAmountWithExchangeRate(
-        [amount, rate3]
-      );
+        const redeem =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            deposit,
+            rate,
+          ]);
 
-      expect(result3).to.equal(parseEther("20"));
-    });
+        expect(redeem).to.equal(amount);
 
-    it("should balance when psm deposit and redeem using exchange rate", async function () {
-      const contract = await loadFixture(deployMathHelper);
+        const rate2 = parseEther("2");
 
-      const amount = parseEther("10");
-      const rate = parseEther("1");
+        const deposit2 =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate2,
+          ]);
 
-      const deposit =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate,
-        ]);
+        const redeem2 =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            deposit2,
+            rate2,
+          ]);
 
-      const redeem = await contract.read.calculateRedeemAmountWithExchangeRate([
-        deposit,
-        rate,
-      ]);
+        expect(redeem2).to.equal(amount);
 
-      expect(redeem).to.equal(amount);
+        const rate3 = parseEther("0.5");
 
-      const rate2 = parseEther("2");
+        console.log(
+          `depositing ${formatEther(amount)} RA with rate ${formatEther(rate3)}`
+        );
 
-      const deposit2 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate2,
-        ]);
+        const deposit3 =
+          await contract.read.calculateDepositAmountWithExchangeRate([
+            amount,
+            rate3,
+          ]);
 
-      const redeem2 = await contract.read.calculateRedeemAmountWithExchangeRate(
-        [deposit2, rate2]
-      );
+        console.log(`got ${formatEther(deposit3)} DS from deposit`);
+        console.log(
+          `redeeeming ${formatEther(deposit3)} DS with rate ${formatEther(
+            rate3
+          )}`
+        );
 
-      expect(redeem2).to.equal(amount);
+        const redeem3 =
+          await contract.read.calculateRedeemAmountWithExchangeRate([
+            deposit3,
+            rate3,
+          ]);
 
-      const rate3 = parseEther("0.5");
+        console.log(`redeemed ${formatEther(redeem3)} RA`);
 
-      const deposit3 =
-        await contract.read.calculateDepositAmountWithExchangeRate([
-          amount,
-          rate3,
-        ]);
-
-      console.log(`got ${formatEther(deposit3)} from deposit`);
-      console.log(
-        `redeeeming ${formatEther(deposit3)} with rate ${formatEther(rate3)}`
-      );
-
-      const redeem3 = await contract.read.calculateRedeemAmountWithExchangeRate(
-        [deposit3, rate3]
-      );
-
-      console.log(`redeemed ${formatEther(redeem3)}`);
-
-      expect(redeem3).to.equal(amount);
+        expect(redeem3).to.equal(amount);
+      });
     });
   });
 });


### PR DESCRIPTION
This reverses psm exchange rate logic :
eR = 0.5
before : 
- if you deposit 1 RA, you would get 0.5 Ds(1 x 0.5)
- if you redeem 0.5 Ds, you would get 1 RA(0.5 / 0.5)
after :
- if you deposit 1 RA, you would get 2 Ds(1 / 0.5),
- if you redeem 2 DS, you would get 1 RA(2 x 0.5)