### PR TITLE
Uniswap V2 Integration

### DIFF
--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -21,14 +21,21 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
     using PsmLibrary for State;
     using PairLibrary for Pair;
 
-
     constructor(
         address swapAssetFactory,
         address ammFactory,
         address flashSwapRouter,
-        address ammRouter
-    , address config) ModuleState(swapAssetFactory, ammFactory, flashSwapRouter, ammRouter, config) {}
-
+        address ammRouter,
+        address config
+    )
+        ModuleState(
+            swapAssetFactory,
+            ammFactory,
+            flashSwapRouter,
+            ammRouter,
+            config
+        )
+    {}
 
     function getId(address pa, address ra) external pure returns (Id) {
         return PairLibrary.initalize(pa, ra).toId();
@@ -54,7 +61,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
             revert AlreadyInitialized();
         }
 
-        IAssetFactory factory = IAssetFactory(_factory);
+        IAssetFactory factory = IAssetFactory(swapAssetFactory);
 
         address lv = factory.deployLv(ra, pa, address(this));
 
@@ -82,7 +89,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
 
         address ra = state.info.pair1;
 
-        (address _ct, address _ds) = IAssetFactory(_factory).deploySwapAssets(
+        (address ct, address ds) = IAssetFactory(swapAssetFactory).deploySwapAssets(
             ra,
             state.info.pair0,
             address(this),

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -24,8 +24,9 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
     constructor(
         address swapAssetFactory,
         address ammFactory,
-        address flashSwapRouter
-    ) ModuleState(swapAssetFactory, ammFactory, flashSwapRouter) {}
+        address flashSwapRouter,
+        address ammRouter
+    ) ModuleState(swapAssetFactory, ammFactory, flashSwapRouter, ammRouter) {}
 
     function getId(address pa, address ra) external pure returns (Id) {
         return PairLibrary.initalize(pa, ra).toId();
@@ -107,7 +108,12 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         // TODO : 0 for initial reserve for now, will be calculated later when rollover stragegy is implemented
         getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0);
 
-        VaultLibrary.onNewIssuance(state, prevIdx, getRouterCore());
+        VaultLibrary.onNewIssuance(
+            state,
+            prevIdx,
+            getRouterCore(),
+            getAmmRouter()
+        );
 
         emit Issued(id, idx, expiry, ds, ct, ammPair);
     }

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -99,7 +99,6 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
             prevIdx,
             repurchaseFeePrecentage
         );
-        VaultLibrary.onNewIssuance(state, prevIdx);
 
         IUniswapV2Factory ammFactory = getAmmFactory();
 
@@ -107,6 +106,8 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
 
         // TODO : 0 for initial reserve for now, will be calculated later when rollover stragegy is implemented
         getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0);
+
+        VaultLibrary.onNewIssuance(state, prevIdx, getRouterCore());
 
         emit Issued(id, idx, expiry, ds, ct, ammPair);
     }

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -19,7 +19,10 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
     using PsmLibrary for State;
     using PairLibrary for Pair;
 
-    constructor(address factory) ModuleState(factory) {}
+    constructor(
+        address swapAssetFactory,
+        address ammFactory
+    ) ModuleState(swapAssetFactory, ammFactory) {}
 
     function getId(address pa, address ra) external pure returns (Id) {
         return PairLibrary.initalize(pa, ra).toId();
@@ -45,7 +48,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
             revert AlreadyInitialized();
         }
 
-        IAssetFactory factory = IAssetFactory(_factory);
+        IAssetFactory factory = getSwapAssetFactory();
 
         address lv = factory.deployLv(ra, pa, address(this));
 
@@ -74,7 +77,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         address pa = state.info.pair0;
         address ra = state.info.pair1;
 
-        (address _ct, address _ds) = IAssetFactory(_factory).deploySwapAssets(
+        (address _ct, address _ds) = getSwapAssetFactory().deploySwapAssets(
             ra,
             pa,
             address(this),

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -78,12 +78,11 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
     ) external override onlyInitialized(id) {
         State storage state = states[id];
 
-        address pa = state.info.pair0;
         address ra = state.info.pair1;
 
         (address ct, address ds) = getSwapAssetFactory().deploySwapAssets(
             ra,
-            pa,
+            state.info.pair0,
             address(this),
             expiry,
             exchangeRates
@@ -92,18 +91,17 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         uint256 prevIdx = state.globalAssetIdx++;
         uint256 idx = state.globalAssetIdx;
 
+        address ammPair = getAmmFactory().createPair(ra, ct);
+
         PsmLibrary.onNewIssuance(
             state,
             ct,
             ds,
+            ammPair,
             idx,
             prevIdx,
             repurchaseFeePrecentage
         );
-
-        IUniswapV2Factory ammFactory = getAmmFactory();
-
-        address ammPair = ammFactory.createPair(ra, ct);
 
         // TODO : 0 for initial reserve for now, will be calculated later when rollover stragegy is implemented
         getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0);

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -105,8 +105,8 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
 
         address ammPair = ammFactory.createPair(ra, ct);
 
-        // TODO : 0 for both initial reserve for now, will be calculated later when rollover stragegy is implemented
-        getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0, 0);
+        // TODO : 0 for initial reserve for now, will be calculated later when rollover stragegy is implemented
+        getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0);
 
         emit Issued(id, idx, expiry, ds, ct, ammPair);
     }

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -24,22 +24,33 @@ abstract contract ModuleState is ICommon {
     /// @dev in this case is uni v2
     address ammRouter;
 
+    address config;
+
+    /** @dev checks if caller is config contract or not
+     */
+    modifier onlyConfig() {
+        if (msg.sender != config) {
+            revert OnlyConfigAllowed();
+        }
+        _;
+    }
+
     function factory() external view returns (address) {
         return swapAssetFactory;
     }
 
-    constructor(address _factory, address _config) {
-        factoryAddress = _factory;
-        configAddress = _config;
     constructor(
         address _swapAssetFactory,
         address _ammFactory,
         address _dsFlashSwapRouter,
-        address _ammRouter
+        address _ammRouter,
+        address _config
     ) {
         swapAssetFactory = _swapAssetFactory;
         ammFactory = _ammFactory;
         dsFlashSwapRouter = _dsFlashSwapRouter;
+        _ammRouter = _ammRouter;
+        config = _config;
     }
 
     function getSwapAssetFactory() internal view returns (IAssetFactory) {

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -11,18 +11,21 @@ abstract contract ModuleState is ICommon {
     using PsmLibrary for State;
 
     mapping(Id => State) internal states;
-    address _factory;
+    address swapAssetFactory;
+    /// @dev in this case is uni v2
+    address ammFactory;
 
     function factory() external view returns (address) {
-        return _factory;
+        return swapAssetFactory;
     }
 
-    constructor(address factoryAddress) {
-        _factory = factoryAddress;
+    constructor(address _swapAssetFactory, address _ammFactory) {
+        swapAssetFactory = _swapAssetFactory;
+        ammFactory = _ammFactory;
     }
 
-    function getFactory() internal view returns (IAssetFactory) {
-        return IAssetFactory(_factory);
+    function getSwapAssetFactory() internal view returns (IAssetFactory) {
+        return IAssetFactory(swapAssetFactory);
     }
 
     modifier onlyInitialized(Id id) {
@@ -33,7 +36,7 @@ abstract contract ModuleState is ICommon {
     }
 
     function _onlyValidAsset(address asset) internal view {
-        if (getFactory().isDeployed(asset) == false) {
+        if (getSwapAssetFactory().isDeployed(asset) == false) {
             revert InvalidAsset(asset);
         }
     }

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -49,7 +49,7 @@ abstract contract ModuleState is ICommon {
         swapAssetFactory = _swapAssetFactory;
         ammFactory = _ammFactory;
         dsFlashSwapRouter = _dsFlashSwapRouter;
-        _ammRouter = _ammRouter;
+        ammRouter = _ammRouter;
         config = _config;
     }
 

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -6,6 +6,8 @@ import "../libraries/State.sol";
 import "../interfaces/IAssetFactory.sol";
 import "../interfaces/ICommon.sol";
 import "../libraries/PsmLib.sol";
+import "../interfaces/uniswap-v2/factory.sol";
+import "./flash-swaps/RouterState.sol";
 
 abstract contract ModuleState is ICommon {
     using PsmLibrary for State;
@@ -15,17 +17,32 @@ abstract contract ModuleState is ICommon {
     /// @dev in this case is uni v2
     address ammFactory;
 
+    address dsFlashSwapRouter;
+
     function factory() external view returns (address) {
         return swapAssetFactory;
     }
 
-    constructor(address _swapAssetFactory, address _ammFactory) {
+    constructor(
+        address _swapAssetFactory,
+        address _ammFactory,
+        address _dsFlashSwapRouter
+    ) {
         swapAssetFactory = _swapAssetFactory;
         ammFactory = _ammFactory;
+        dsFlashSwapRouter = _dsFlashSwapRouter;
     }
 
     function getSwapAssetFactory() internal view returns (IAssetFactory) {
         return IAssetFactory(swapAssetFactory);
+    }
+
+    function getRouterCore() internal view returns (RouterState) {
+        return RouterState(dsFlashSwapRouter);
+    }
+
+    function getAmmFactory() internal view returns (IUniswapV2Factory) {
+        return IUniswapV2Factory(ammFactory);
     }
 
     modifier onlyInitialized(Id id) {

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -8,16 +8,21 @@ import "../interfaces/ICommon.sol";
 import "../libraries/PsmLib.sol";
 import "../interfaces/uniswap-v2/factory.sol";
 import "./flash-swaps/RouterState.sol";
+import "../interfaces/uniswap-v2/RouterV2.sol";
 
 abstract contract ModuleState is ICommon {
     using PsmLibrary for State;
 
     mapping(Id => State) internal states;
     address swapAssetFactory;
+
     /// @dev in this case is uni v2
     address ammFactory;
 
     address dsFlashSwapRouter;
+
+    /// @dev in this case is uni v2
+    address ammRouter;
 
     function factory() external view returns (address) {
         return swapAssetFactory;
@@ -26,7 +31,8 @@ abstract contract ModuleState is ICommon {
     constructor(
         address _swapAssetFactory,
         address _ammFactory,
-        address _dsFlashSwapRouter
+        address _dsFlashSwapRouter,
+        address _ammRouter
     ) {
         swapAssetFactory = _swapAssetFactory;
         ammFactory = _ammFactory;
@@ -43,6 +49,10 @@ abstract contract ModuleState is ICommon {
 
     function getAmmFactory() internal view returns (IUniswapV2Factory) {
         return IUniswapV2Factory(ammFactory);
+    }
+
+    function getAmmRouter() internal view returns (IUniswapV2Router02) {
+        return IUniswapV2Router02(ammRouter);
     }
 
     modifier onlyInitialized(Id id) {

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -26,7 +26,12 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
             uint256 feePrecentage,
             uint256 fee,
             uint256 exchangeRates
-        ) = state.repurchase(_msgSender(), amount, getRouterCore());
+        ) = state.repurchase(
+                _msgSender(),
+                amount,
+                getRouterCore(),
+                getAmmRouter()
+            );
 
         emit Repurchased(
             id,

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -26,7 +26,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
             uint256 feePrecentage,
             uint256 fee,
             uint256 exchangeRates
-        ) = state.repurchase(_msgSender(), amount);
+        ) = state.repurchase(_msgSender(), amount, getRouterCore());
 
         emit Repurchased(
             id,

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -85,7 +85,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
     {
         State storage state = states[id];
         (attributedRa, attributedPa, approvedAmount) = state
-            .previewRedeemExpired(amount, _msgSender());
+            .previewRedeemExpired(amount, _msgSender(), getRouterCore());
     }
 
     function redeemEarlyLv(
@@ -95,7 +95,13 @@ abstract contract VaultCore is ModuleState, Context, IVault {
     ) external override {
         State storage state = states[id];
         (uint256 received, uint256 fee, uint256 feePrecentage) = state
-            .redeemEarly(_msgSender(), receiver, amount, getRouterCore());
+            .redeemEarly(
+                _msgSender(),
+                receiver,
+                amount,
+                getRouterCore(),
+                getAmmRouter()
+            );
 
         emit LvRedeemEarly(
             id,
@@ -117,6 +123,9 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         returns (uint256 received, uint256 fee, uint256 feePrecentage)
     {
         State storage state = states[id];
-        (received, fee, feePrecentage) = state.previewRedeemEarly(amount);
+        (received, fee, feePrecentage) = state.previewRedeemEarly(
+            amount,
+            getRouterCore()
+        );
     }
 }

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -63,7 +63,9 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         (uint256 attributedRa, uint256 attributedPa) = state.redeemExpired(
             _msgSender(),
             receiver,
-            amount
+            amount,
+            getAmmRouter(),
+            getRouterCore()
         );
         emit LvRedeemExpired(id, receiver, attributedRa, attributedPa);
     }

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -20,7 +20,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
 
     function depositLv(Id id, uint256 amount) external override {
         State storage state = states[id];
-        state.deposit(_msgSender(), amount);
+        state.deposit(_msgSender(), amount, getRouterCore());
         emit LvDeposited(id, _msgSender(), amount);
     }
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -20,7 +20,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
 
     function depositLv(Id id, uint256 amount) external override {
         State storage state = states[id];
-        state.deposit(_msgSender(), amount, getRouterCore());
+        state.deposit(_msgSender(), amount, getRouterCore(), getAmmRouter());
         emit LvDeposited(id, _msgSender(), amount);
     }
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -93,7 +93,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
     ) external override {
         State storage state = states[id];
         (uint256 received, uint256 fee, uint256 feePrecentage) = state
-            .redeemEarly(_msgSender(), receiver, amount);
+            .redeemEarly(_msgSender(), receiver, amount, getRouterCore());
 
         emit LvRedeemEarly(
             id,

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -25,6 +25,18 @@ abstract contract RouterState is
         reserves[reserveId].onNewIssuance(dsId, ds, pair, initialReserve);
     }
 
+    function getCurrentPriceRatio(
+        Id id,
+        uint256 dsId
+    )
+        external
+        view
+        override
+        returns (uint256 raPriceRatio, uint256 ctPriceRatio)
+    {
+        (raPriceRatio, ctPriceRatio) = reserves[id].getPriceRatio(dsId);
+    }
+
     function addReserve(
         Id id,
         uint256 dsId,

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -6,7 +6,11 @@ import "../../libraries/Pair.sol";
 import "../../interfaces/IDsFlashSwapRouter.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-abstract contract RouterState is IDsFlashSwapUtility, Ownable {
+abstract contract RouterState is
+    IDsFlashSwapUtility,
+    IDsFlashSwapCore,
+    Ownable
+{
     using DsFlashSwaplibrary for ReserveState;
 
     mapping(Id => ReserveState) reserves;
@@ -17,7 +21,7 @@ abstract contract RouterState is IDsFlashSwapUtility, Ownable {
         address ds,
         address pair,
         uint256 initialReserve
-    ) external onlyOwner {
+    ) external override onlyOwner {
         reserves[reserveId].onNewIssuance(dsId, ds, pair, initialReserve);
     }
 
@@ -25,7 +29,7 @@ abstract contract RouterState is IDsFlashSwapUtility, Ownable {
         Id id,
         uint256 dsId,
         uint256 amount
-    ) external onlyOwner {
+    ) external override onlyOwner {
         reserves[id].addReserve(dsId, amount);
     }
 

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -38,11 +38,40 @@ contract RouterState is
         reserves[reserveId].onNewIssuance(dsId, ds, pair, initialReserve);
     }
 
+    function getAmmReserve(
+        Id id,
+        uint256 dsId
+    ) external view override returns (uint112 raReserve, uint112 ctReserve) {
+        (raReserve, ctReserve) = reserves[id].getReserve(dsId);
+    }
+
+    function getLvReserve(
+        Id id,
+        uint256 dsId
+    ) external view override returns (uint256 lvReserve) {
+        return reserves[id].ds[dsId].reserve;
+    }
+
+    function getUniV2pair(
+        Id id,
+        uint256 dsId
+    ) external view override returns (IUniswapV2Pair pair) {
+        return reserves[id].getPair(dsId);
+    }
+
     function emptyReserve(
         Id reserveId,
         uint256 dsId
-    ) external returns (uint256 amount) {
+    ) external override onlyOwner returns (uint256 amount) {
         return reserves[reserveId].emptyReserve(dsId, owner());
+    }
+
+    function emptyReservePartial(
+        Id reserveId,
+        uint256 dsId,
+        uint256 amount
+    ) external override onlyOwner returns (uint256 reserve) {
+        return reserves[reserveId].emptyReservePartial(dsId, amount, owner());
     }
 
     function getCurrentPriceRatio(

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -49,7 +49,7 @@ abstract contract RouterState is
         uint256 dsId,
         uint256 amount
     ) external override onlyOwner {
-        reserves[id].addReserve(dsId, amount);
+        reserves[id].addReserve(dsId, amount, owner());
     }
 
     function getState(

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -4,16 +4,29 @@ pragma solidity ^0.8.0;
 import "../../libraries/DsFlashSwap.sol";
 import "../../libraries/Pair.sol";
 import "../../interfaces/IDsFlashSwapRouter.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-abstract contract RouterState is
+contract RouterState is
     IDsFlashSwapUtility,
     IDsFlashSwapCore,
-    Ownable
+    OwnableUpgradeable,
+    UUPSUpgradeable
 {
     using DsFlashSwaplibrary for ReserveState;
 
+    constructor() {}
+
+    function initialize(address moduleCore) external initializer notDelegated {
+        __Ownable_init(moduleCore);
+        __UUPSUpgradeable_init();
+    }
+
     mapping(Id => ReserveState) reserves;
+
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner notDelegated {}
 
     function onNewIssuance(
         Id reserveId,

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.0;
 
 import "../../libraries/DsFlashSwap.sol";
 import "../../libraries/Pair.sol";
+import "../../interfaces/IDsFlashSwapRouter.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-abstract contract RouterState {
+abstract contract RouterState is IDsFlashSwapUtility, Ownable {
     using DsFlashSwaplibrary for ReserveState;
 
     mapping(Id => ReserveState) reserves;
@@ -16,7 +18,7 @@ abstract contract RouterState {
         address pair,
         uint256 initialReserve,
         uint256 initialLvReserve
-    ) internal {
+    ) external onlyOwner {
         reserves[reserveId].onNewIssuance(
             dsId,
             ds,
@@ -35,7 +37,7 @@ abstract contract RouterState {
     function getCurrentDsPrice(
         Id id,
         uint256 dsId
-    ) internal view returns (uint256 price) {
+    ) external view returns (uint256 price) {
         return reserves[id].getCurrentDsPrice(dsId);
     }
 
@@ -43,7 +45,7 @@ abstract contract RouterState {
         Id id,
         uint256 dsId,
         uint256 amountOut
-    ) internal view returns (uint256 amountIn) {
+    ) external view returns (uint256 amountIn) {
         return reserves[id].getAmountIn(dsId, amountOut);
     }
 
@@ -51,7 +53,7 @@ abstract contract RouterState {
         Id id,
         uint256 dsId,
         uint256 amountIn
-    ) internal view returns (uint256 amountOut) {
+    ) external view returns (uint256 amountOut) {
         return reserves[id].getAmountOut(dsId, amountIn);
     }
 }

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -16,16 +16,17 @@ abstract contract RouterState is IDsFlashSwapUtility, Ownable {
         uint256 dsId,
         address ds,
         address pair,
-        uint256 initialReserve,
-        uint256 initialLvReserve
+        uint256 initialReserve
     ) external onlyOwner {
-        reserves[reserveId].onNewIssuance(
-            dsId,
-            ds,
-            pair,
-            initialReserve,
-            initialLvReserve
-        );
+        reserves[reserveId].onNewIssuance(dsId, ds, pair, initialReserve);
+    }
+
+    function addReserve(
+        Id id,
+        uint256 dsId,
+        uint256 amount
+    ) external onlyOwner {
+        reserves[id].addReserve(dsId, amount);
     }
 
     function getState(

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../../libraries/DsFlashSwap.sol";
+import "../../libraries/Pair.sol";
+
+abstract contract RouterState {
+    using DsFlashSwaplibrary for ReserveState;
+
+    mapping(Id => ReserveState) reserves;
+
+    function onNewIssuance(
+        Id reserveId,
+        uint256 dsId,
+        address ds,
+        address pair,
+        uint256 initialReserve,
+        uint256 initialLvReserve
+    ) internal {
+        reserves[reserveId].onNewIssuance(
+            dsId,
+            ds,
+            pair,
+            initialReserve,
+            initialLvReserve
+        );
+    }
+
+    function getState(
+        Id id
+    ) internal view returns (ReserveState storage reserve) {
+        return reserves[id];
+    }
+
+    function getCurrentDsPrice(
+        Id id,
+        uint256 dsId
+    ) internal view returns (uint256 price) {
+        return reserves[id].getCurrentDsPrice(dsId);
+    }
+
+    function getAmountIn(
+        Id id,
+        uint256 dsId,
+        uint256 amountOut
+    ) internal view returns (uint256 amountIn) {
+        return reserves[id].getAmountIn(dsId, amountOut);
+    }
+
+    function getAmountOut(
+        Id id,
+        uint256 dsId,
+        uint256 amountIn
+    ) internal view returns (uint256 amountOut) {
+        return reserves[id].getAmountOut(dsId, amountIn);
+    }
+}

--- a/contracts/core/flash-swaps/RouterState.sol
+++ b/contracts/core/flash-swaps/RouterState.sol
@@ -25,6 +25,13 @@ abstract contract RouterState is
         reserves[reserveId].onNewIssuance(dsId, ds, pair, initialReserve);
     }
 
+    function emptyReserve(
+        Id reserveId,
+        uint256 dsId
+    ) external returns (uint256 amount) {
+        return reserves[reserveId].emptyReserve(dsId, owner());
+    }
+
     function getCurrentPriceRatio(
         Id id,
         uint256 dsId

--- a/contracts/dummy/DummyWETH.sol
+++ b/contracts/dummy/DummyWETH.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+
+// dummy contract for RA and PA
+contract DummyWETH is ERC20Burnable {
+    event Deposit(address indexed dst, uint wad);
+    event Withdrawal(address indexed src, uint wad);
+
+    constructor() ERC20("Wrapped ETH", "WETH") {}
+
+    fallback() external payable {
+        deposit();
+    }
+
+    receive() external payable {
+        deposit();
+    }
+
+    function deposit() public payable {
+        _mint(msg.sender, msg.value);
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint wad) public {
+        _burn(msg.sender, wad);
+
+        payable(msg.sender).transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+}

--- a/contracts/interfaces/ICommon.sol
+++ b/contracts/interfaces/ICommon.sol
@@ -28,12 +28,16 @@ interface ICommon {
     /// @param Id The PSM id
     /// @param dsId The DS id
     /// @param expiry The expiry of the DS
+    /// @param ds The address of the DS token
+    /// @param ct The address of the CT token
+    /// @param raCtUniPair The address of the uniswap-v2 pair between RA and CT
     event Issued(
         Id indexed Id,
         uint256 indexed dsId,
         uint256 indexed expiry,
         address ds,
-        address ct
+        address ct,
+        address raCtUniPair
     );
 
     /**

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -21,3 +21,15 @@ interface IDsFlashSwapUtility {
         uint256 amountIn
     ) external view returns (uint256 amountOut);
 }
+
+interface IDsFlashSwapCore {
+    function onNewIssuance(
+        Id reserveId,
+        uint256 dsId,
+        address ds,
+        address pair,
+        uint256 initialReserve
+    ) external;
+
+    function addReserve(Id id, uint256 dsId, uint256 amount) external;
+}

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+import "../libraries/Pair.sol";
+import "../libraries/DsFlashSwap.sol";
+
+interface IDsFlashSwapUtility {
+    function getCurrentDsPrice(
+        Id id,
+        uint256 dsId
+    ) external view returns (uint256 price);
+
+    function getAmountIn(
+        Id id,
+        uint256 dsId,
+        uint256 amountOut
+    ) external view returns (uint256 amountIn);
+
+    function getAmountOut(
+        Id id,
+        uint256 dsId,
+        uint256 amountIn
+    ) external view returns (uint256 amountOut);
+}

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -22,7 +22,7 @@ interface IDsFlashSwapUtility {
     ) external view returns (uint256 amountOut);
 
     function getCurrentPriceRatio(
-        Id id ,
+        Id id,
         uint256 dsId
     ) external view returns (uint256 raPriceRatio, uint256 ctPriceRatio);
 }
@@ -37,4 +37,9 @@ interface IDsFlashSwapCore {
     ) external;
 
     function addReserve(Id id, uint256 dsId, uint256 amount) external;
+
+    function emptyReserve(
+        Id reserveId,
+        uint256 dsId
+    ) external returns (uint256 amount);
 }

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -20,6 +20,11 @@ interface IDsFlashSwapUtility {
         uint256 dsId,
         uint256 amountIn
     ) external view returns (uint256 amountOut);
+
+    function getCurrentPriceRatio(
+        Id id ,
+        uint256 dsId
+    ) external view returns (uint256 raPriceRatio, uint256 ctPriceRatio);
 }
 
 interface IDsFlashSwapCore {

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -25,9 +25,24 @@ interface IDsFlashSwapUtility {
         Id id,
         uint256 dsId
     ) external view returns (uint256 raPriceRatio, uint256 ctPriceRatio);
+
+    function getAmmReserve(
+        Id id,
+        uint256 dsId
+    ) external view returns (uint112 raReserve, uint112 ctReserve);
+
+    function getLvReserve(
+        Id id,
+        uint256 dsId
+    ) external view returns (uint256 lvReserve);
+
+    function getUniV2pair(
+        Id id,
+        uint256 dsId
+    ) external view returns (IUniswapV2Pair pair);
 }
 
-interface IDsFlashSwapCore {
+interface IDsFlashSwapCore is IDsFlashSwapUtility {
     function onNewIssuance(
         Id reserveId,
         uint256 dsId,
@@ -42,4 +57,10 @@ interface IDsFlashSwapCore {
         Id reserveId,
         uint256 dsId
     ) external returns (uint256 amount);
+
+    function emptyReservePartial(
+        Id reserveId,
+        uint256 dsId,
+        uint256 amount
+    ) external returns (uint256 reserve);
 }

--- a/contracts/interfaces/uniswap-v2/RouterV1.sol
+++ b/contracts/interfaces/uniswap-v2/RouterV1.sol
@@ -1,0 +1,150 @@
+pragma solidity ^0.8.0;
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB, uint liquidity);
+
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    )
+        external
+        payable
+        returns (uint amountToken, uint amountETH, uint liquidity);
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB);
+
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountETH);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint amountA, uint amountB);
+
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint amountToken, uint amountETH);
+
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapExactETHForTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    function swapTokensForExactETH(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapExactTokensForETH(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapETHForExactTokens(
+        uint amountOut,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    function quote(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) external pure returns (uint amountB);
+
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) external pure returns (uint amountOut);
+
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) external pure returns (uint amountIn);
+
+    function getAmountsOut(
+        uint amountIn,
+        address[] calldata path
+    ) external view returns (uint[] memory amounts);
+
+    function getAmountsIn(
+        uint amountOut,
+        address[] calldata path
+    ) external view returns (uint[] memory amounts);
+}

--- a/contracts/interfaces/uniswap-v2/RouterV2.sol
+++ b/contracts/interfaces/uniswap-v2/RouterV2.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.8.0;
+
+import './RouterV1.sol';
+
+interface IUniswapV2Router02 is IUniswapV2Router01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}

--- a/contracts/interfaces/uniswap-v2/Univ2Pair.sol
+++ b/contracts/interfaces/uniswap-v2/Univ2Pair.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.8.0;
+
+interface IUniswapV2Pair {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external pure returns (string memory);
+    function symbol() external pure returns (string memory);
+    function decimals() external pure returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+    function nonces(address owner) external view returns (uint);
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+
+    event Mint(address indexed sender, uint amount0, uint amount1);
+    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint);
+    function factory() external view returns (address);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function price0CumulativeLast() external view returns (uint);
+    function price1CumulativeLast() external view returns (uint);
+    function kLast() external view returns (uint);
+
+    function mint(address to) external returns (uint liquidity);
+    function burn(address to) external returns (uint amount0, uint amount1);
+    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    function skim(address to) external;
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/contracts/interfaces/uniswap-v2/factory.sol
+++ b/contracts/interfaces/uniswap-v2/factory.sol
@@ -1,0 +1,18 @@
+// taken directly from forked repo
+pragma solidity ^0.8.0;
+
+interface IUniswapV2Factory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+
+    function getPair(address tokenA, address tokenB) external view returns (address pair);
+    function allPairs(uint) external view returns (address pair);
+    function allPairsLength() external view returns (uint);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+
+    function setFeeTo(address) external;
+    function setFeeToSetter(address) external;
+}

--- a/contracts/libraries/DepegSwapLib.sol
+++ b/contracts/libraries/DepegSwapLib.sol
@@ -8,6 +8,8 @@ struct DepegSwap {
     bool expiredEventEmitted;
     address _address;
     address ct;
+    /// @dev right now this the RA:CT AMM pair address
+    address ammPair;
     uint256 dsRedeemed;
     uint256 ctRedeemed;
 }
@@ -43,12 +45,14 @@ library DepegSwapLibrary {
 
     function initialize(
         address _address,
-        address ct
+        address ct,
+        address ammPair
     ) internal pure returns (DepegSwap memory) {
         return
             DepegSwap({
                 expiredEventEmitted: false,
                 _address: _address,
+                ammPair: ammPair,
                 ct: ct,
                 dsRedeemed: 0,
                 ctRedeemed: 0

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -33,15 +33,31 @@ library DsFlashSwaplibrary {
         );
     }
 
+    function getPair(
+        ReserveState storage self,
+        uint256 dsId
+    ) internal view returns (IUniswapV2Pair) {
+        return self.ds[dsId].pair;
+    }
+
     function emptyReserve(
         ReserveState storage self,
         uint256 dsId,
         address to
     ) internal returns (uint256 reserve) {
-        self.ds[dsId].ds.transfer(to, self.ds[dsId].reserve);
+        reserve = emptyReservePartial(self, dsId, self.ds[dsId].reserve, to);
+    }
 
+    function emptyReservePartial(
+        ReserveState storage self,
+        uint256 dsId,
+        uint256 amount,
+        address to
+    ) internal returns (uint256 reserve) {
+        self.ds[dsId].ds.transfer(to, amount);
+
+        self.ds[dsId].reserve -= amount;
         reserve = self.ds[dsId].reserve;
-        self.ds[dsId].reserve = 0;
     }
 
     function getPriceRatio(
@@ -59,6 +75,13 @@ library DsFlashSwaplibrary {
         );
     }
 
+    function getReserve(
+        ReserveState storage self,
+        uint256 dsId
+    ) internal view returns (uint112 raReserve, uint112 ctReserve) {
+        (raReserve, ctReserve, ) = self.ds[dsId].pair.getReserves();
+    }
+
     function addReserve(
         ReserveState storage self,
         uint256 dsId,
@@ -66,7 +89,7 @@ library DsFlashSwaplibrary {
         address from
     ) internal returns (uint256 reserve) {
         self.ds[dsId].ds.transferFrom(from, address(this), amount);
-        
+
         self.ds[dsId].reserve += amount;
         reserve = self.ds[dsId].reserve;
     }

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -8,12 +8,10 @@ struct AssetPair {
     Asset ds;
     /// @dev [RA, CT]
     IUniswapV2Pair pair;
-    /// @dev this is the amount that the flash swap router has in reserve
-    uint256 reserve;
     /// @dev this represent the amount of DS that the LV has in reserve
     /// will be used to fullfill buy DS orders based on the LV DS selling strategy
     // (i.e 50:50 for first expiry, and 80:20 on subsequent expiries. note that it's represented as LV:AMM)
-    uint256 lvReserve;
+    uint256 reserve;
 }
 struct ReserveState {
     /// @dev dsId => [RA, CT, DS]
@@ -26,15 +24,22 @@ library DsFlashSwaplibrary {
         uint256 dsId,
         address ds,
         address pair,
-        uint256 initialReserve,
-        uint256 initialLvReserve
+        uint256 initialReserve
     ) internal {
         self.ds[dsId] = AssetPair(
             Asset(ds),
             IUniswapV2Pair(pair),
-            initialReserve,
-            initialLvReserve
+            initialReserve
         );
+    }
+
+    function addReserve(
+        ReserveState storage self,
+        uint256 dsId,
+        uint256 amount
+    ) internal returns (uint256 reserve) {
+        self.ds[dsId].reserve += amount;
+        reserve = self.ds[dsId].reserve;
     }
 
     function getCurrentDsPrice(

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -39,7 +39,7 @@ library DsFlashSwaplibrary {
         address to
     ) internal returns (uint256 reserve) {
         self.ds[dsId].ds.transfer(to, self.ds[dsId].reserve);
-        
+
         reserve = self.ds[dsId].reserve;
         self.ds[dsId].reserve = 0;
     }
@@ -62,8 +62,11 @@ library DsFlashSwaplibrary {
     function addReserve(
         ReserveState storage self,
         uint256 dsId,
-        uint256 amount
+        uint256 amount,
+        address from
     ) internal returns (uint256 reserve) {
+        self.ds[dsId].ds.transferFrom(from, address(this), amount);
+        
         self.ds[dsId].reserve += amount;
         reserve = self.ds[dsId].reserve;
     }

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -33,6 +33,21 @@ library DsFlashSwaplibrary {
         );
     }
 
+    function getPriceRatio(
+        ReserveState storage self,
+        uint256 dsId
+    ) internal view returns (uint256 raPriceRatio, uint256 ctPriceRatio) {
+        (uint112 raReserve, uint112 ctReserve, ) = self
+            .ds[dsId]
+            .pair
+            .getReserves();
+
+        (raPriceRatio, ctPriceRatio) = SwapperMathLibrary.getPriceRatioUniv2(
+            raReserve,
+            ctReserve
+        );
+    }
+
     function addReserve(
         ReserveState storage self,
         uint256 dsId,

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -33,6 +33,17 @@ library DsFlashSwaplibrary {
         );
     }
 
+    function emptyReserve(
+        ReserveState storage self,
+        uint256 dsId,
+        address to
+    ) internal returns (uint256 reserve) {
+        self.ds[dsId].ds.transfer(to, self.ds[dsId].reserve);
+        
+        reserve = self.ds[dsId].reserve;
+        self.ds[dsId].reserve = 0;
+    }
+
     function getPriceRatio(
         ReserveState storage self,
         uint256 dsId

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -8,6 +8,12 @@ struct AssetPair {
     Asset ds;
     /// @dev [RA, CT]
     IUniswapV2Pair pair;
+    /// @dev this is the amount that the flash swap router has in reserve
+    uint256 reserve;
+    /// @dev this represent the amount of DS that the LV has in reserve
+    /// will be used to fullfill buy DS orders based on the LV DS selling strategy
+    // (i.e 50:50 for first expiry, and 80:20 on subsequent expiries. note that it's represented as LV:AMM)
+    uint256 lvReserve;
 }
 struct ReserveState {
     /// @dev dsId => [RA, CT, DS]
@@ -19,9 +25,16 @@ library DsFlashSwaplibrary {
         ReserveState storage self,
         uint256 dsId,
         address ds,
-        address pair
+        address pair,
+        uint256 initialReserve,
+        uint256 initialLvReserve
     ) internal {
-        self.ds[dsId] = AssetPair(Asset(ds), IUniswapV2Pair(pair));
+        self.ds[dsId] = AssetPair(
+            Asset(ds),
+            IUniswapV2Pair(pair),
+            initialReserve,
+            initialLvReserve
+        );
     }
 
     function getCurrentDsPrice(

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -10,7 +10,7 @@ library SwapperMathLibrary {
     error InsufficientLiquidity();
     error InsufficientOtuputAmount();
 
-    function getPriceRatios(
+    function getPriceRatioUniv2(
         uint112 raReserve,
         uint112 ctReserve
     ) public pure returns (uint256 raPriceRatio, uint256 ctPriceRatio) {
@@ -36,7 +36,7 @@ library SwapperMathLibrary {
         uint112 ctReserve,
         uint256 dsExchangeRate
     ) public pure returns (uint256 price) {
-        (, uint256 ctPriceRatio) = getPriceRatios(raReserve, ctReserve);
+        (, uint256 ctPriceRatio) = getPriceRatioUniv2(raReserve, ctReserve);
 
         price = dsExchangeRate - ctPriceRatio;
     }

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -11,6 +11,7 @@ library SwapperMathLibrary {
     error InsufficientLiquidity();
     error InsufficientOtuputAmount();
 
+    // Calculate price ratio of two tokens in a uniswap v2 pair, will return ratio on 18 decimals precision
     function getPriceRatioUniv2(
         uint112 raReserve,
         uint112 ctReserve
@@ -28,8 +29,9 @@ library SwapperMathLibrary {
         uint224 ctPriceRatioUQ = encodedRaReserve.uqdiv(ctReserve);
 
         // Convert UQ112x112 to regular uint (divide by 2**112)
-        raPriceRatio = uint256(raPriceRatioUQ) / UQ112x112.Q112;
-        ctPriceRatio = uint256(ctPriceRatioUQ) / UQ112x112.Q112;
+        // we time by 18 to have 18 decimals precision
+        raPriceRatio = (uint256(raPriceRatioUQ) * 1e18) / UQ112x112.Q112;
+        ctPriceRatio = (uint256(ctPriceRatioUQ) * 1e18) / UQ112x112.Q112;
     }
 
     function calculateDsPrice(

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -15,7 +15,7 @@ library SwapperMathLibrary {
         uint112 raReserve,
         uint112 ctReserve
     ) public pure returns (uint256 raPriceRatio, uint256 ctPriceRatio) {
-        if (raReserve > 0 || ctReserve > 0) {
+        if (raReserve <= 0 || ctReserve <= 0) {
             revert ZeroReserve();
         }
 

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 import "./UQ112x112.sol";
 
 // library function for handling math operations for DS swap contract
+// TODO : separately test this
 library SwapperMathLibrary {
     using UQ112x112 for uint224;
     error ZeroReserve();

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -214,6 +214,6 @@ library MathHelper {
         uint256 rateRaPerLp,
         uint256 redeemedLv
     ) external pure returns (uint256 lpLiquidated) {
-        lpLiquidated = ((redeemedLv * rateRaPerLv) * 1e18) / rateRaPerLp;
+        lpLiquidated = ((redeemedLv * rateRaPerLv) * 1e18) / rateRaPerLp / 1e18;
     }
 }

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -27,7 +27,7 @@ library MathHelper {
     // using ra and ct, which both has 18 decimals so will default into that one for now
     /// @dev should only pass ERC20.decimals() onto the decimal field
     /// @dev will output price ratio in 18 decimal precision.
-    function calculatePriceRatio(
+    function calculatePriceRatioUniV4(
         uint160 sqrtPriceX96,
         uint8 decimal
     ) external pure returns (uint256) {

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -139,13 +139,15 @@ library MathHelper {
             uint256 ratePerLv
         )
     {
-        // attribute all to AMM if no lv issued or withdrawn
-        if (totalLvIssued == 0 || totalLvWithdrawn == 0) {
-            return (0, totalAmount, 0);
-        }
-
         // with 1e18 precision
         ratePerLv = ((totalAmount * 1e18) / totalLvIssued);
+
+        // attribute all to AMM if no lv issued or withdrawn
+        if (totalLvIssued == 0 || totalLvWithdrawn == 0) {
+            return (0, totalAmount, ratePerLv);
+        }
+
+        
         attributedWithdrawal = (ratePerLv * totalLvWithdrawn) / 1e18;
         attributedAmm = totalAmount - attributedWithdrawal;
 

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -186,7 +186,9 @@ library MathHelper {
             uint256 raValuePerLv,
             uint256 ctValuePerLv,
             uint256 valueRaPerLp,
-            uint256 valueCtPerLp
+            uint256 valueCtPerLp,
+            uint256 totalLvRaValue,
+            uint256 totalLvCtValue
         )
     {
         (valueRaPerLp, valueCtPerLp) = calculateUniV2LpValue(
@@ -202,5 +204,16 @@ library MathHelper {
 
         raValuePerLv = (cumulatedLptotalLvOwnedRa * 1e18) / totalLvIssued;
         ctValuePerLv = (cumulatedLptotalLvOwnedCt * 1e18) / totalLvIssued;
+
+        totalLvRaValue = raValuePerLv * totalLvIssued;
+        totalLvCtValue = ctValuePerLv * totalLvIssued;
+    }
+
+    function convertToLp(
+        uint256 rateRaPerLv,
+        uint256 rateRaPerLp,
+        uint256 redeemedLv
+    ) external pure returns (uint256 lpLiquidated) {
+        lpLiquidated = ((redeemedLv * rateRaPerLv) * 1e18) / rateRaPerLp;
     }
 }

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -5,6 +5,11 @@ library MathHelper {
     /// @dev default decimals for now to calculate price ratio
     uint8 internal constant DEFAULT_DECIMAL = 18;
 
+    // TODO : discuss what value of this should be set to. currently set to 1% tolerance.
+    // this is used to calculate tolerance level when adding liqudity to AMM pair
+    /// @dev 1e18 == 1%.
+    uint256 internal constant UNIV2_STATIC_TOLERANCE = 1000000000000000000;
+
     /**
      * @dev calculate the amount of ra and ct needed to provide AMM with liquidity in respect to the price ratio
      *
@@ -107,7 +112,6 @@ library MathHelper {
         _amount = (amount * exchangeRate) / 1e18;
     }
 
-    // TODO : unit test this, just move here from psm
     /// @notice calculate the accrued PA & RA
     /// @dev this function follow below equation :
     /// '#' refers to the total circulation supply of that token.
@@ -146,5 +150,19 @@ library MathHelper {
         attributedAmm = totalAmount - attributedWithdrawal;
 
         assert((attributedWithdrawal + attributedAmm) == totalAmount);
+    }
+
+    function calculateWithTolreance(
+        uint256 ra,
+        uint256 ct,
+        uint256 tolerance
+    ) external pure returns (uint256 raTolerance, uint256 ctTolerance) {
+        raTolerance = (ra * tolerance) / 1e18;
+        ctTolerance = (ct * tolerance) / 1e18;
+    }
+
+    function name() external pure returns (string memory) {
+        return "MathHelper";
+        
     }
 }

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -205,8 +205,8 @@ library MathHelper {
         raValuePerLv = (cumulatedLptotalLvOwnedRa * 1e18) / totalLvIssued;
         ctValuePerLv = (cumulatedLptotalLvOwnedCt * 1e18) / totalLvIssued;
 
-        totalLvRaValue = raValuePerLv * totalLvIssued;
-        totalLvCtValue = ctValuePerLv * totalLvIssued;
+        totalLvRaValue = (raValuePerLv * totalLvIssued) / 1e18;
+        totalLvCtValue = (ctValuePerLv * totalLvIssued) / 1e18;
     }
 
     function convertToLp(

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -270,7 +270,8 @@ library PsmLibrary {
         State storage self,
         address buyer,
         uint256 amount,
-        RouterState flashSwapRouter
+        RouterState flashSwapRouter,
+        IUniswapV2Router02 ammRouter
     )
         internal
         returns (
@@ -312,7 +313,8 @@ library PsmLibrary {
         VaultLibrary.provideLiquidityWithPsmRepurchase(
             self,
             fee,
-            flashSwapRouter
+            flashSwapRouter,
+            ammRouter
         );
     }
 

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -270,7 +270,7 @@ library PsmLibrary {
         State storage self,
         address buyer,
         uint256 amount,
-        IDsFlashSwapCore flashSwapRouter
+        RouterState flashSwapRouter
     )
         internal
         returns (

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -269,7 +269,8 @@ library PsmLibrary {
     function repurchase(
         State storage self,
         address buyer,
-        uint256 amount
+        uint256 amount,
+        IDsFlashSwapCore flashSwapRouter
     )
         internal
         returns (
@@ -308,7 +309,11 @@ library PsmLibrary {
         IERC20(ds._address).transfer(buyer, received);
 
         // Provide liquidity
-        VaultLibrary.provideLiquidityWithPsmRepurchase(self, fee);
+        VaultLibrary.provideLiquidityWithPsmRepurchase(
+            self,
+            fee,
+            flashSwapRouter
+        );
     }
 
     function _redeemDs(
@@ -516,15 +521,8 @@ library PsmLibrary {
             archive.paAccrued
         );
 
-        _beforeCtRedeem(
-            self,
-            ds,
-            dsId,
-            amount,
-            accruedPa,
-            accruedRa
-        );
-        
+        _beforeCtRedeem(self, ds, dsId, amount, accruedPa, accruedRa);
+
         _afterCtRedeem(
             self,
             ds,

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -333,7 +333,7 @@ library PsmLibrary {
         IERC20(ds._address).transfer(buyer, received);
 
         // Provide liquidity
-        VaultLibrary.provideLiquidityWithPsmRepurchase(
+        VaultLibrary.provideLiquidityWithFee(
             self,
             fee,
             flashSwapRouter,

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -11,6 +11,7 @@ import "./State.sol";
 import "./Guard.sol";
 import "./MathHelper.sol";
 import "../interfaces/IRepurchase.sol";
+import "../interfaces/IDsFlashSwapRouter.sol";
 import "./VaultLib.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
@@ -69,7 +70,6 @@ library PsmLibrary {
         DepegSwap storage ds = self.ds[prevIdx];
         Guard.safeAfterExpired(ds);
 
-        uint256 totalCtIssued = IERC20(ds.ct).totalSupply();
         uint256 availableRa = self.psm.balances.ra.convertAllToFree();
         uint256 availablePa = self.psm.balances.paBalance;
 
@@ -148,7 +148,6 @@ library PsmLibrary {
         PsmPoolArchive storage archive = self.psm.poolArchive[dsId];
 
         (accruedPa, accruedRa) = _calcRedeemAmount(
-            self,
             amount,
             totalCtIssued,
             archive.raAccrued,
@@ -294,7 +293,7 @@ library PsmLibrary {
         State storage self,
         address buyer,
         uint256 amount,
-        RouterState flashSwapRouter,
+        IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
     )
         internal
@@ -462,12 +461,11 @@ library PsmLibrary {
     }
 
     function _calcRedeemAmount(
-        State storage self,
         uint256 amount,
         uint256 totalCtIssued,
         uint256 availableRa,
         uint256 availablePa
-    ) internal view returns (uint256 accruedPa, uint256 accruedRa) {
+    ) internal pure returns (uint256 accruedPa, uint256 accruedRa) {
         accruedPa = MathHelper.calculateAccrued(
             amount,
             availablePa,
@@ -540,7 +538,6 @@ library PsmLibrary {
         PsmPoolArchive storage archive = self.psm.poolArchive[dsId];
 
         (accruedPa, accruedRa) = _calcRedeemAmount(
-            self,
             amount,
             totalCtIssued,
             archive.raAccrued,
@@ -584,7 +581,6 @@ library PsmLibrary {
         }
 
         (accruedPa, accruedRa) = _calcRedeemAmount(
-            self,
             amount,
             totalCtIssued,
             availableRa,

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -81,7 +81,6 @@ struct VaultConfig {
     //
     uint256 ammCtDepositThreshold;
     uint256 lpCtBalance;
-    uint256 accmulatedFee;
     // 
     uint256 lpBalance;
 }

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -82,4 +82,6 @@ struct VaultConfig {
     uint256 ammCtDepositThreshold;
     uint256 lpCtBalance;
     uint256 accmulatedFee;
+    // 
+    uint256 lpBalance;
 }

--- a/contracts/libraries/VaultConfig.sol
+++ b/contracts/libraries/VaultConfig.sol
@@ -15,7 +15,8 @@ library VaultConfigLibrary {
                 lpRaBalance: 0,
                 lpCtBalance: 0,
                 ammCtDepositThreshold: ammCtDepositThreshold,
-                accmulatedFee: 0
+                accmulatedFee: 0,
+                lpBalance: 0
             });
     }
 

--- a/contracts/libraries/VaultConfig.sol
+++ b/contracts/libraries/VaultConfig.sol
@@ -15,7 +15,6 @@ library VaultConfigLibrary {
                 lpRaBalance: 0,
                 lpCtBalance: 0,
                 ammCtDepositThreshold: ammCtDepositThreshold,
-                accmulatedFee: 0,
                 lpBalance: 0
             });
     }

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -76,26 +76,8 @@ library VaultLibrary {
             );
 
         ERC20(raAddress).approve(address(ammRouter), raAmount);
-        console.log(
-            "Approving RA               : %s to %s",
-            raAmount,
-            address(ammRouter)
-        );
-        console.log(
-            "Contract RA balance        : %s",
-            ERC20(raAddress).balanceOf(address(this))
-        );
 
         ERC20(ctAddress).approve(address(ammRouter), ctAmount);
-        console.log(
-            "Approving CT           : %s to %s",
-            ctAmount,
-            address(ammRouter)
-        );
-        console.log(
-            "Contract CT balance    : %s",
-            ERC20(ctAddress).balanceOf(address(this))
-        );
 
         // TODO : what do we do if there's leftover deposit due to the tolerance level? for now will just ignore it.
         (uint256 raDeposited, uint256 ctDeposited, uint256 lp) = ammRouter
@@ -403,7 +385,7 @@ library VaultLibrary {
         uint256 ctAttributedToPa = reservedDs > ctAmm ? 0 : ctAmm - reservedDs;
 
         uint256 psmPa;
-        uint256 psmRa;
+        uint256 psmRa = redeemAmount;
 
         if (ctAttributedToPa != 0) {
             (psmPa, psmRa) = PsmLibrary.lvRedeemRaPaWithCt(

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -47,7 +47,7 @@ library VaultLibrary {
         uint256 ammWaDepositThreshold,
         uint256 ammCtDepositThreshold,
         address ra
-    ) internal {
+    ) external {
         self.config = VaultConfigLibrary.initialize(
             fee,
             ammWaDepositThreshold,
@@ -111,7 +111,7 @@ library VaultLibrary {
         uint256 prevDsId,
         IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
-    ) internal {
+    ) external {
         // do nothing at first issuance
         if (prevDsId == 0) {
             return;
@@ -136,7 +136,7 @@ library VaultLibrary {
         Guard.safeBeforeExpired(ds);
     }
 
-    function safeAfterExpired(State storage self) internal view {
+    function safeAfterExpired(State storage self) external view {
         uint256 dsId = self.globalAssetIdx;
         DepegSwap storage ds = self.ds[dsId];
         Guard.safeAfterExpired(ds);
@@ -241,7 +241,7 @@ library VaultLibrary {
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
-    ) internal {
+    ) external {
         safeBeforeExpired(self);
         self.vault.balances.ra.lockUnchecked(amount, from);
         __provideLiquidityWithRatio(
@@ -258,7 +258,7 @@ library VaultLibrary {
     // returns the amount of shares(share pool token) that user will receive
     function previewDeposit(
         uint256 amount
-    ) internal pure returns (uint256 lvReceived) {
+    ) external pure returns (uint256 lvReceived) {
         lvReceived = amount;
     }
 
@@ -266,7 +266,7 @@ library VaultLibrary {
         State storage self,
         address owner,
         uint256 amount
-    ) internal {
+    ) external {
         safeBeforeExpired(self);
         self.vault.pool.withdrawEligible[owner] += amount;
         self.vault.pool.withdrawalPool.atrributedLv += amount;
@@ -276,7 +276,7 @@ library VaultLibrary {
     function lvLockedFor(
         State storage self,
         address owner
-    ) internal view returns (uint256) {
+    ) external view returns (uint256) {
         return self.vault.pool.withdrawEligible[owner];
     }
 
@@ -284,7 +284,7 @@ library VaultLibrary {
         State storage self,
         address owner,
         uint256 amount
-    ) internal {
+    ) external {
         safeBeforeExpired(self);
         uint256 userEligible = self.vault.pool.withdrawEligible[owner];
 
@@ -306,7 +306,7 @@ library VaultLibrary {
         address from,
         address to,
         uint256 amount
-    ) internal {
+    ) external {
         uint256 initialOwneramount = self.vault.pool.withdrawEligible[from];
 
         if (initialOwneramount == 0) {
@@ -492,7 +492,7 @@ library VaultLibrary {
 
     function reservedForWithdrawal(
         State storage self
-    ) internal view returns (uint256 ra, uint256 pa) {
+    ) external view returns (uint256 ra, uint256 pa) {
         ra = self.vault.pool.withdrawalPool.raBalance;
         pa = self.vault.pool.withdrawalPool.paBalance;
     }
@@ -617,7 +617,7 @@ library VaultLibrary {
         uint256 amount,
         IUniswapV2Router02 ammRouter,
         IDsFlashSwapCore flashSwapRouter
-    ) internal returns (uint256 attributedRa, uint256 attributedPa) {
+    ) external returns (uint256 attributedRa, uint256 attributedPa) {
         uint256 dsId = self.globalAssetIdx;
         DepegSwap storage ds = self.ds[dsId];
 
@@ -669,7 +669,7 @@ library VaultLibrary {
         address owner,
         IDsFlashSwapCore flashSwapRouter
     )
-        internal
+        external
         view
         returns (
             uint256 attributedRa,
@@ -769,7 +769,7 @@ library VaultLibrary {
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
-    ) internal returns (uint256 received, uint256 fee, uint256 feePrecentage) {
+    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage) {
         safeBeforeExpired(self);
 
         feePrecentage = self.vault.config.fee;
@@ -835,7 +835,7 @@ library VaultLibrary {
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter
     )
-        internal
+        external
         view
         returns (uint256 received, uint256 fee, uint256 feePrecentage)
     {
@@ -870,7 +870,7 @@ library VaultLibrary {
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
-    ) internal {
+    ) external {
         __provideLiquidityWithRatio(
             self,
             amount,

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -117,8 +117,10 @@ library VaultLibrary {
     function _addFlashSwapReserve(
         State storage self,
         RouterState flashSwapRouter,
+        DepegSwap storage ds,
         uint256 amount
     ) internal {
+        Asset(ds._address).approve(address(flashSwapRouter), amount);
         flashSwapRouter.addReserve(
             self.info.toId(),
             self.globalAssetIdx,
@@ -170,9 +172,10 @@ library VaultLibrary {
         address ctAddress,
         IUniswapV2Router02 ammRouter
     ) internal returns (uint256 ra, uint256 ct) {
+        uint256 dsId = self.globalAssetIdx;
         (uint256 raRatio, ) = flashSwapRouter.getCurrentPriceRatio(
             self.info.toId(),
-            self.globalAssetIdx
+            dsId
         );
 
         (ra, ct) = MathHelper.calculateAmounts(amount, raRatio);
@@ -187,7 +190,7 @@ library VaultLibrary {
 
         PsmLibrary.unsafeIssueToLv(self, ct);
 
-        _addFlashSwapReserve(self, flashSwapRouter, amount);
+        _addFlashSwapReserve(self, flashSwapRouter, self.ds[dsId], amount);
     }
 
     function deposit(

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -193,6 +193,11 @@ library VaultLibrary {
         IUniswapV2Router02 ammRouter,
         uint256 dsId
     ) internal {
+        // no need to provide liquidity if the amount is 0
+        if (raAmount == 0 && ctAmount == 0) {
+            return;
+        }
+
         PsmLibrary.unsafeIssueToLv(self, ctAmount);
 
         __addLiquidityToAmmUnchecked(
@@ -339,6 +344,8 @@ library VaultLibrary {
             address(this),
             block.timestamp
         );
+
+        self.vault.config.lpBalance = 0;
     }
 
     function _liquidatedLp(
@@ -348,6 +355,12 @@ library VaultLibrary {
         RouterState flashSwapRouter
     ) internal {
         DepegSwap storage ds = self.ds[dsId];
+
+        // if there's no LP, then there's nothing to liquidate
+        if (self.vault.config.lpBalance == 0) {
+            return;
+        }
+
         // TODO : placeholder
         // the following things should happen here(taken directly from the whitepaper) :
         // 1. The AMM LP is redeemed to receive CT + RA

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -16,8 +16,6 @@ import "../interfaces/IDsFlashSwapRouter.sol";
 import "../interfaces/IDsFlashSwapRouter.sol";
 import "../interfaces/uniswap-v2/RouterV2.sol";
 
-import "hardhat/console.sol";
-
 library VaultLibrary {
     using VaultConfigLibrary for VaultConfig;
     using PairLibrary for Pair;
@@ -640,7 +638,6 @@ library VaultLibrary {
 
         totalRa = (raPerLv * lvRedeemed) / 1e18;
         uint256 ammCtBalance = (ctPerLv * lvRedeemed) / 1e18;
-        console.log("totalRa", totalRa);
 
         lpLiquidated = MathHelper.convertToLp(raPerLv, raPerLp, lvRedeemed);
 
@@ -649,7 +646,6 @@ library VaultLibrary {
             ammCtBalance
             ? ammCtBalance
             : flashSwapRouter.getLvReserve(self.info.toId(), dsId);
-        console.log("totalRa", totalRa);
 
         uint256 excessCt = flashSwapRouter.getLvReserve(
             self.info.toId(),
@@ -666,7 +662,6 @@ library VaultLibrary {
             excessCt,
             ctPerLp
         );
-        console.log("totalRa", totalRa);
     }
 
     function _trySellCtToAmm(

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -15,8 +15,6 @@ import "../interfaces/IDsFlashSwapRouter.sol";
 import "../core/flash-swaps/RouterState.sol";
 import "../interfaces/uniswap-v2/RouterV2.sol";
 
-import "hardhat/console.sol";
-
 library VaultLibrary {
     using VaultConfigLibrary for VaultConfig;
     using PairLibrary for Pair;

--- a/contracts/libraries/uni-v2/UniswapV2Library.sol
+++ b/contracts/libraries/uni-v2/UniswapV2Library.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.8.0;
+
+library MinimalUniswapV2Library {
+    // 0.3%
+    uint public constant FEE = 997;
+    // 0%
+    uint public constant NO_FEE = 1000;
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    // WARNING: won't apply fee since we don't take fee from user right now
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) internal pure returns (uint amountOut) {
+        require(amountIn > 0, "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT");
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
+        uint amountInWithFee = amountIn * NO_FEE;
+        uint numerator = amountInWithFee * reserveOut;
+        uint denominator = reserveIn * 1000;
+        amountOut = numerator / denominator;
+    }
+
+    // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+    // WARNING: won't apply fee since we don't take fee from user right now
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) internal pure returns (uint amountIn) {
+        require(amountOut > 0, "UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT");
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
+        uint numerator = reserveIn * amountOut * 1000;
+        uint denominator = reserveOut * NO_FEE;
+        amountIn = (numerator / denominator);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,6 +16,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
+      evmVersion: "cancun",
     },
   },
   networks: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,7 +37,7 @@ const config: HardhatUserConfig = {
   },
   contractSizer: {
     runOnCompile: true,
-    only: ["ModuleCore", "AssetFactory", "MathHelper"],
+    only: ["ModuleCore", "AssetFactory", "MathHelper", "VaultLibrary", "PsmLibrary"],
   },
 };
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,9 +1,14 @@
 import { HardhatUserConfig } from "hardhat/config";
+
 import "@nomicfoundation/hardhat-toolbox-viem";
 import "hardhat-gas-reporter";
 import "@nomicfoundation/hardhat-viem";
 import loadEnv from "dotenv";
 import "hardhat-contract-sizer";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+
+chai.use(solidity);
 // import "@nomicfoundation/hardhat-chai-matchers";
 
 loadEnv.config();
@@ -37,7 +42,13 @@ const config: HardhatUserConfig = {
   },
   contractSizer: {
     runOnCompile: true,
-    only: ["ModuleCore", "AssetFactory", "MathHelper", "VaultLibrary", "PsmLibrary"],
+    only: [
+      "ModuleCore",
+      "AssetFactory",
+      "MathHelper",
+      "VaultLibrary",
+      "PsmLibrary",
+    ],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "scripts": {
     "test": "npx hardhat test",
-    "lint:contract":"npx solhint 'contracts/**/*.sol'",
-    "lint:contract:fix":"npx solhint 'contracts/**/*.sol' --fix"
+    "lint:contract": "npx solhint 'contracts/**/*.sol'",
+    "lint:contract:fix": "npx solhint 'contracts/**/*.sol' --fix"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.7",
@@ -22,6 +22,7 @@
     "@types/mocha": ">=9.1.0",
     "@types/node": ">=18.0.0",
     "chai": "^4.2.0",
+    "ethereum-waffle": "^4.0.10",
     "hardhat": "^2.22.3",
     "hardhat-gas-reporter": "^2.1.1",
     "solidity-coverage": "^0.8.0",
@@ -37,6 +38,7 @@
     "@uniswap/lib": "4.0.1-alpha",
     "@uniswap/v2-core": "1.0.0",
     "dotenv": "^16.4.5",
+    "ethers": "5.6.2",
     "hardhat-contract-sizer": "^2.10.0",
     "solhint": "^5.0.2"
   }

--- a/test/contracts/AssetFactory.ts
+++ b/test/contracts/AssetFactory.ts
@@ -9,23 +9,31 @@ import { Address, formatEther, parseEther, WalletClient } from "viem";
 import * as helper from "../helper/TestHelper";
 
 describe("Asset Factory", function () {
-  let defaultSigner: any;
-  let secondSigner: any;
-  let signers: any;
+  let {
+    defaultSigner,
+    secondSigner,
+    signers,
+  }: ReturnType<typeof helper.getSigners> = {} as any;
 
-  let assetFactory: any;
-
-  before(async () => {
-    ({ defaultSigner, signers } = await helper.getSigners());
-    secondSigner = signers[1];
-  });
-
-  beforeEach(async () => {
-    assetFactory = await hre.viem.deployContract("AssetFactory", [], {
+  let assetFactory: Awaited<ReturnType<typeof deployFactory>>;
+  
+  const deployFactory = async () => {
+    return await hre.viem.deployContract("AssetFactory", [], {
       client: {
         wallet: defaultSigner,
       },
     });
+  };
+
+  before(async () => {
+    const __signers = await hre.viem.getWalletClients();
+    ({ defaultSigner, signers } = helper.getSigners(__signers));
+    secondSigner = signers[1];
+  });
+
+  beforeEach(async () => {
+    assetFactory = await loadFixture(deployFactory);
+
     await assetFactory.write.initialize([defaultSigner.account.address], {
       account: defaultSigner.account,
     });

--- a/test/contracts/CorkConfig.ts
+++ b/test/contracts/CorkConfig.ts
@@ -1,101 +1,124 @@
-import {
-  loadFixture,
-} from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import hre from "hardhat";
 import * as helper from "../helper/TestHelper";
 
 describe("CorkConfig", function () {
-  let defaultSigner: any;
-  let secondSigner: any;
-  let signers: any;
+  let {
+    defaultSigner,
+    secondSigner,
+    signers,
+  }: ReturnType<typeof helper.getSigners> = {} as any;
 
-  let corkConfig: any;
+  let corkConfig: Awaited<ReturnType<typeof helper.deployCorkConfig>>;
 
   before(async () => {
-    ({ defaultSigner, signers } = await helper.getSigners());
+    const __signers = await hre.viem.getWalletClients();
+    ({ defaultSigner, signers } = helper.getSigners(__signers));
     secondSigner = signers[1];
   });
 
   beforeEach(async () => {
-    const corkConfigInstance = await loadFixture(
-      helper.deployCorkConfig
-    );
-    corkConfig = await hre.viem.getContractAt(
-      "CorkConfig",
-      corkConfigInstance.contract.address
-    );
+    corkConfig = await loadFixture(helper.deployCorkConfig);
   });
 
   it("should deploy correctly", async function () {
-    corkConfig = await hre.viem.deployContract("CorkConfig", [],
-      {
-        client: {
-          wallet: defaultSigner,
-        }
-      }
-    );
-    expect(corkConfig).to.be.ok;
-    expect(await corkConfig.read.hasRole([await corkConfig.read.DEFAULT_ADMIN_ROLE(),
-    defaultSigner.account.address]
-    )).to.be.equals(true);
-    expect(await corkConfig.read.hasRole([await corkConfig.read.MANAGER_ROLE(),
-    defaultSigner.account.address]
-    )).to.be.equals(false);
-    expect(await corkConfig.read.paused()).to.be.equals(false);
+    const __corkConfig = await hre.viem.deployContract("CorkConfig", [], {
+      client: {
+        wallet: defaultSigner,
+      },
+    });
+    expect(__corkConfig).to.be.ok;
+    expect(
+      await __corkConfig.read.hasRole([
+        await __corkConfig.read.DEFAULT_ADMIN_ROLE(),
+        defaultSigner.account.address,
+      ])
+    ).to.be.equals(true);
+    expect(
+      await __corkConfig.read.hasRole([
+        await __corkConfig.read.MANAGER_ROLE(),
+        defaultSigner.account.address,
+      ])
+    ).to.be.equals(false);
+    expect(await __corkConfig.read.paused()).to.be.equals(false);
   });
 
   describe("SetModuleCore", function () {
     it("setModuleCore should work correctly", async function () {
-      expect(await corkConfig.read.moduleCore()).to.not.be.equals(defaultSigner.account.address);
-      await expect(await corkConfig.write.setModuleCore([secondSigner.account.address], {
-        account: defaultSigner.account,
-      })).to.be.ok;
-      expect(await (await corkConfig.read.moduleCore()).toLowerCase()).to.be.equals(secondSigner.account.address);
-    })
+      expect(await corkConfig.contract.read.moduleCore()).to.not.be.equals(
+        defaultSigner.account.address
+      );
+      expect(
+        await corkConfig.contract.write.setModuleCore(
+          [secondSigner.account.address],
+          {
+            account: defaultSigner.account,
+          }
+        )
+      ).to.be.ok;
+      expect(
+        await corkConfig.contract.read
+          .moduleCore()
+          .then((result) => result.toLocaleLowerCase())
+      ).to.be.equals(secondSigner.account.address);
+    });
 
     it("Revert when non MANAGER call setModuleCore", async function () {
-      await expect(corkConfig.write.setModuleCore([defaultSigner.account.address], {
-        account: secondSigner.account,
-      })).to.be.rejectedWith('CallerNotManager()');
-    })
+      await expect(
+        corkConfig.contract.write.setModuleCore(
+          [defaultSigner.account.address],
+          {
+            account: secondSigner.account,
+          }
+        )
+      ).to.be.rejectedWith("CallerNotManager()");
+    });
   });
 
   describe("Pause", function () {
     it("pause should work correctly", async function () {
-      expect(await corkConfig.read.paused()).to.be.equals(false);
+      expect(await corkConfig.contract.read.paused()).to.be.equals(false);
 
-      await expect(await corkConfig.write.pause({
-        account: defaultSigner.account,
-      })).to.be.ok;
+      await expect(
+        await corkConfig.contract.write.pause({
+          account: defaultSigner.account,
+        })
+      ).to.be.ok;
 
-      expect(await corkConfig.read.paused()).to.be.equals(true);
-    })
+      expect(await corkConfig.contract.read.paused()).to.be.equals(true);
+    });
 
     it("Revert when non MANAGER call pause", async function () {
-      await expect(corkConfig.write.pause({
-        account: secondSigner.account,
-      })).to.be.rejectedWith('CallerNotManager()');
-    })
-  })
+      await expect(
+        corkConfig.contract.write.pause({
+          account: secondSigner.account,
+        })
+      ).to.be.rejectedWith("CallerNotManager()");
+    });
+  });
 
   describe("Unpause", function () {
     it("unpause should work correctly", async function () {
-      await corkConfig.write.pause();
+      await corkConfig.contract.write.pause();
 
-      expect(await corkConfig.read.paused()).to.be.equals(true);
+      expect(await corkConfig.contract.read.paused()).to.be.equals(true);
 
-      await expect(await corkConfig.write.unpause({
-        account: defaultSigner.account,
-      })).to.be.ok;
+      await expect(
+        await corkConfig.contract.write.unpause({
+          account: defaultSigner.account,
+        })
+      ).to.be.ok;
 
-      expect(await corkConfig.read.paused()).to.be.equals(false);
-    })
+      expect(await corkConfig.contract.read.paused()).to.be.equals(false);
+    });
 
     it("Revert when non MANAGER call pause", async function () {
-      await expect(corkConfig.write.unpause({
-        account: secondSigner.account,
-      })).to.be.rejectedWith('CallerNotManager()');
-    })
-  })
+      await expect(
+        corkConfig.contract.write.unpause({
+          account: secondSigner.account,
+        })
+      ).to.be.rejectedWith("CallerNotManager()");
+    });
+  });
 });

--- a/test/contracts/LvCore.ts
+++ b/test/contracts/LvCore.ts
@@ -4,20 +4,26 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import { Address, formatEther, parseEther, WalletClient } from "viem";
+import hre from "hardhat";
 import * as helper from "../helper/TestHelper";
 
 describe("LvCore", function () {
-  let defaultSigner: any;
-  let secondSigner: any;
-  let signers: any;
+  let {
+    defaultSigner,
+    secondSigner,
+    signers,
+  }: ReturnType<typeof helper.getSigners> = {} as any;
 
-  let depositAmount: any;
-  let expiry :any;
+  let depositAmount: bigint;
+  let expiry: number;
 
-  let fixture: any;
+  let fixture: Awaited<
+    ReturnType<typeof helper.ModuleCoreWithInitializedPsmLv>
+  >;
 
   before(async () => {
-    ({ defaultSigner, signers } = await helper.getSigners());
+    const __signers = await hre.viem.getWalletClients();
+    ({ defaultSigner, signers } = helper.getSigners(__signers));
     secondSigner = signers[1];
   });
 
@@ -25,7 +31,7 @@ describe("LvCore", function () {
     fixture = await loadFixture(helper.ModuleCoreWithInitializedPsmLv);
 
     depositAmount = parseEther("10");
-    expiry = helper.expiry(1000000);    
+    expiry = helper.expiry(1000000);
 
     await fixture.ra.write.mint([defaultSigner.account.address, depositAmount]);
     await fixture.ra.write.mint([secondSigner.account.address, depositAmount]);
@@ -50,7 +56,7 @@ describe("LvCore", function () {
       pa: fixture.pa.address,
       ra: fixture.ra.address,
       factory: fixture.factory.contract.address,
-      ...options
+      ...options,
     });
   }
 
@@ -249,7 +255,9 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(helper.calculateMinimumLiquidity(redeemAmount));
+    expect(event[0].args.ra).to.be.equal(
+      helper.calculateMinimumLiquidity(redeemAmount)
+    );
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 
@@ -356,7 +364,9 @@ describe("LvCore", function () {
         depositAmount,
       ]);
 
-    expect(signer1ra).to.be.equal(helper.calculateMinimumLiquidity(depositAmount));
+    expect(signer1ra).to.be.equal(
+      helper.calculateMinimumLiquidity(depositAmount)
+    );
     expect(signer2pa).to.be.equal(BigInt(0));
     expect(signer1approvedAmount).to.be.equal(parseEther("5"));
   });
@@ -437,7 +447,9 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(helper.calculateMinimumLiquidity(depositAmount));
+    expect(event[0].args.ra).to.be.equal(
+      helper.calculateMinimumLiquidity(depositAmount)
+    );
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 

--- a/test/contracts/LvCore.ts
+++ b/test/contracts/LvCore.ts
@@ -603,7 +603,7 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(depositAmount);
+    expect(event[0].args.ra).to.be.equal(helper.calculateMinimumLiquidity(depositAmount));
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 

--- a/test/contracts/LvCore.ts
+++ b/test/contracts/LvCore.ts
@@ -96,18 +96,7 @@ describe("LvCore", function () {
       }
     );
 
-    await fixture.moduleCore.contract.write.requestRedemption(
-      [Id, depositAmount],
-      {
-        account: secondSigner.account,
-      }
-    );
-
-    expect(
-      await fixture.lv.read.balanceOf([secondSigner.account.address])
-    ).to.be.equal(parseEther("0"));
-
-    await time.increase(expiry + 1);
+    await time.increaseTo(expiry + 1e3);
 
     const initialModuleCoreLvBalance = await fixture.lv.read.balanceOf([
       fixture.moduleCore.contract.address,
@@ -124,10 +113,6 @@ describe("LvCore", function () {
       fixture.moduleCore.contract.address,
     ]);
 
-    expect(afterModuleCoreLvBalance).to.be.equal(
-      initialModuleCoreLvBalance - depositAmount
-    );
-
     const event = await fixture.moduleCore.contract.getEvents.LvRedeemExpired({
       Id: lv,
       receiver: secondSigner.account.address,
@@ -135,7 +120,9 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(depositAmount);
+    expect(event[0].args.ra).to.be.equal(
+      helper.calculateMinimumLiquidity(depositAmount)
+    );
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 
@@ -238,7 +225,9 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(depositAmount);
+    expect(event[0].args.ra).to.be.equal(
+      helper.calculateMinimumLiquidity(depositAmount)
+    );
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 
@@ -313,7 +302,7 @@ describe("LvCore", function () {
 
     expect(event.length).to.be.equal(1);
 
-    expect(event[0].args.ra).to.be.equal(redeemAmount);
+    expect(event[0].args.ra).to.be.equal(helper.calculateMinimumLiquidity(redeemAmount));
     expect(event[0].args.pa).to.be.equal(BigInt(0));
   });
 
@@ -486,7 +475,7 @@ describe("LvCore", function () {
         depositAmount,
       ]);
 
-    expect(signer1ra).to.be.equal(depositAmount);
+    expect(signer1ra).to.be.equal(helper.calculateMinimumLiquidity(depositAmount));
     expect(signer2pa).to.be.equal(BigInt(0));
     expect(signer1approvedAmount).to.be.equal(parseEther("5"));
   });
@@ -694,7 +683,7 @@ describe("LvCore", function () {
     const [ra, pa] =
       await fixture.moduleCore.contract.read.reservedUserWithdrawal([Id]);
 
-    expect(ra).to.be.equal(depositAmount);
+    expect(ra).to.be.equal(helper.calculateMinimumLiquidity(depositAmount));
     expect(pa).to.be.equal(BigInt(0));
   });
 

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -13,10 +13,26 @@ describe("ModuleCore", function () {
 
     const mathLib = await hre.viem.deployContract("MathHelper");
 
+    const dsFlashSwapRouter = await helper.deployFlashSwapRouter();
+    const univ2Factory = await helper.deployUniV2Factory();
+    const weth = await helper.deployWeth();
+    const univ2Router = await helper.deployUniV2Router(
+      weth.contract.address,
+      univ2Factory,
+      dsFlashSwapRouter.contract.address
+    );
+    const swapAssetFactory = await helper.deployAssetFactory();
+    const config = await helper.deployCorkConfig();
+
     const contract = await hre.viem.deployContract(
       "ModuleCore",
-      [defaultSigner.account.address, defaultSigner.account.address],
-
+      [
+        swapAssetFactory.contract.address,
+        univ2Factory,
+        dsFlashSwapRouter.contract.address,
+        univ2Router,
+        config.contract.address,
+      ],
       {
         client: {
           wallet: defaultSigner,

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -24,7 +24,7 @@ describe("ModuleCore", function () {
     const swapAssetFactory = await helper.deployAssetFactory();
     const config = await helper.deployCorkConfig();
 
-    moduleCore = await hre.viem.deployContract(
+    const moduleCore = await hre.viem.deployContract(
       "ModuleCore",
       [
         swapAssetFactory.contract.address,
@@ -42,9 +42,6 @@ describe("ModuleCore", function () {
         },
       }
     );
-  });
-
-  it("should deploy", async function () {
     expect(moduleCore).to.be.ok;
   });
 });

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -9,9 +9,14 @@ import * as helper from "../helper/TestHelper";
 
 describe("ModuleCore", function () {
   it("should deploy", async function () {
-    const { defaultSigner } = await helper.getSigners();
+    const { defaultSigner } =  helper.getSigners(await hre.viem.getWalletClients());
 
     const mathLib = await hre.viem.deployContract("MathHelper");
+    const vault = await hre.viem.deployContract("VaultLibrary", [], {
+      libraries: {
+        MathHelper: mathLib.address,
+      },
+    });
 
     const dsFlashSwapRouter = await helper.deployFlashSwapRouter();
     const univ2Factory = await helper.deployUniV2Factory();
@@ -39,6 +44,7 @@ describe("ModuleCore", function () {
         },
         libraries: {
           MathHelper: mathLib.address,
+          VaultLibrary: vault.address,
         },
       }
     );

--- a/test/contracts/PsmCore.ts
+++ b/test/contracts/PsmCore.ts
@@ -947,7 +947,7 @@ describe("PSM core", function () {
   });
 
   // @yusak found this, cannot issue new DS on the third time while depositing to LV
-  // caused by not actually mint CT + DS at issun
+  // caused by not actually mint CT + DS at issuance
   it("should be able to issue DS for the third time", async function () {
     const { defaultSigner } = await helper.getSigners();
     const fixture = await loadFixture(helper.ModuleCoreWithInitializedPsmLv);
@@ -967,6 +967,8 @@ describe("PSM core", function () {
     let expiry = helper.expiry(expiryInterval);
 
     for (let i = 0; i < 10; i++) {
+      console.log("Issuing DS for the", i + 1, "time");
+      
       await fixture.config.contract.write.issueNewDs(
         [Id, BigInt(expiry), parseEther("1"), parseEther("10")],
         {
@@ -979,7 +981,7 @@ describe("PSM core", function () {
         expiry: BigInt(expiry),
       });
 
-      await fixture.moduleCore.contract.write.depositLv([Id, parseEther("5")]);
+      await fixture.moduleCore.contract.write.depositLv([Id, parseEther("10")]);
 
       await fixture.lv.write.approve([
         fixture.moduleCore.contract.address,

--- a/test/contracts/PsmCore.ts
+++ b/test/contracts/PsmCore.ts
@@ -28,9 +28,7 @@ describe("PSM core", function () {
   });
 
   beforeEach(async () => {
-    fixture = await loadFixture(
-      helper.ModuleCoreWithInitializedPsmLv
-    );
+    fixture = await loadFixture(helper.ModuleCoreWithInitializedPsmLv);
 
     moduleCore = await hre.viem.getContractAt(
       "ModuleCore",
@@ -66,7 +64,7 @@ describe("PSM core", function () {
       pa: fixture.pa.address,
       ra: fixture.ra.address,
       factory: fixture.factory.contract.address,
-      ...options
+      ...options,
     });
   }
 
@@ -96,11 +94,11 @@ describe("PSM core", function () {
 
   describe("commons", function () {
     it("should deposit", async function () {
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
-      const { dsId } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 10000);
+      const { dsId } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 10000
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("10")],
@@ -122,11 +120,11 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000);
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("10")],
@@ -164,8 +162,6 @@ describe("PSM core", function () {
         fixture.Id,
       ]);
 
-      console.log("locked balance", formatEther(lockedBalance));
-
       await fixture.moduleCore.contract.write.redeemRaWithDs(
         [fixture.Id, dsId!, parseEther("10"), permitmsg, deadline],
         {
@@ -190,11 +186,11 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, depositAmount]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, depositAmount]);
 
-      const { dsId, ds, ct, expiry } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 10000);
+      const { dsId, ds, ct, expiry } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 10000
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, depositAmount],
@@ -241,11 +237,11 @@ describe("PSM core", function () {
 
   describe("with exchange rate", function () {
     it("should deposit with correct exchange rate", async function () {
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
-      const { dsId } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 10000);
+      const { dsId } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 10000
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("10")],
@@ -267,14 +263,15 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
       // 2 RA
       const rates = parseEther("2");
 
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000, { rates: rates });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000,
+        { rates: rates }
+      );
       const depositAmount = parseEther("10");
       const expectedAMount = parseEther("5");
 
@@ -331,14 +328,15 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
       // 2 RA
       const rates = parseEther("2");
 
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000, { rates: rates });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000,
+        { rates: rates }
+      );
       const depositAmount = parseEther("10");
       const expectedAMount = parseEther("5");
 
@@ -367,11 +365,12 @@ describe("PSM core", function () {
   describe("cancel position", function () {
     it("should cancel position", async function () {
       mintAmount = parseEther("1");
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 10000, { rates: parseEther("0.5") });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 10000,
+        { rates: parseEther("0.5") }
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("1")],
@@ -443,11 +442,12 @@ describe("PSM core", function () {
     });
 
     it("should preview cancel position", async function () {
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("10")]
-      );
+      pa.write.approve([fixture.moduleCore.contract.address, parseEther("10")]);
 
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 10000, { rates: parseEther("0.5") });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 10000,
+        { rates: parseEther("0.5") }
+      );
 
       const [raAmount, rates] =
         await fixture.moduleCore.contract.read.previewRedeemRaWithCtDs([
@@ -465,13 +465,17 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("100")]
-      );
+      pa.write.approve([
+        fixture.moduleCore.contract.address,
+        parseEther("100"),
+      ]);
 
       // 2 RA for every DS
       const rates = parseEther("2");
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000, { rates: rates });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000,
+        { rates: rates }
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("100")],
@@ -554,13 +558,17 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("100")]
-      );
+      pa.write.approve([
+        fixture.moduleCore.contract.address,
+        parseEther("100"),
+      ]);
 
       // 2 RA for every DS
       const rates = parseEther("2");
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000, { rates: rates });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000,
+        { rates: rates }
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("100")],
@@ -623,13 +631,17 @@ describe("PSM core", function () {
       // just to buffer
       const deadline = BigInt(helper.expiry(expiryTime));
 
-      pa.write.approve(
-        [fixture.moduleCore.contract.address, parseEther("100")]
-      );
+      pa.write.approve([
+        fixture.moduleCore.contract.address,
+        parseEther("100"),
+      ]);
 
       // 1 RA for every DS
       const rates = parseEther("1");
-      const { dsId, ds, ct } = await issueNewSwapAssets(helper.nowTimestampInSeconds() + 1000, { rates: rates });
+      const { dsId, ds, ct } = await issueNewSwapAssets(
+        helper.nowTimestampInSeconds() + 1000,
+        { rates: rates }
+      );
 
       await fixture.moduleCore.contract.write.depositPsm(
         [fixture.Id, parseEther("100")],
@@ -750,8 +762,6 @@ describe("PSM core", function () {
     let expiry = helper.expiry(expiryInterval);
 
     for (let i = 0; i < 10; i++) {
-      console.log("Issuing DS for the", i + 1, "time");
-      
       await fixture.config.contract.write.issueNewDs(
         [Id, BigInt(expiry), parseEther("1"), parseEther("10")],
         {

--- a/test/contracts/PsmCore.ts
+++ b/test/contracts/PsmCore.ts
@@ -4,26 +4,41 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import hre from "hardhat";
-import { Address, formatEther, parseEther, WalletClient } from "viem";
+import {
+  Address,
+  formatEther,
+  GetContractReturnType,
+  parseEther,
+  WalletClient,
+} from "viem";
 import * as helper from "../helper/TestHelper";
-import exp from "constants";
+import { ArtifactsMap } from "hardhat/types/artifacts";
 
 describe("PSM core", function () {
-  let defaultSigner: any;
-  let secondSigner: any;
-  let signers: any;
+  let {
+    defaultSigner,
+    secondSigner,
+    signers,
+  }: ReturnType<typeof helper.getSigners> = {} as any;
 
-  let expiryTime: any;
-  let mintAmount: any;
+  let mintAmount: bigint;
+  let expiryTime: number;
 
-  let fixture: any;
+  let fixture: Awaited<
+    ReturnType<typeof helper.ModuleCoreWithInitializedPsmLv>
+  >;
 
-  let moduleCore: any;
+  let moduleCore: Awaited<ReturnType<typeof getModuleCore>>;
   let corkConfig: any;
   let pa: any;
 
+  const getModuleCore = async (address: Address) => {
+    return await hre.viem.getContractAt("ModuleCore", address);
+  };
+
   before(async () => {
-    ({ defaultSigner, signers } = await helper.getSigners());
+    const __signers = await hre.viem.getWalletClients();
+    ({ defaultSigner, signers } = helper.getSigners(__signers));
     secondSigner = signers[1];
   });
 
@@ -34,6 +49,7 @@ describe("PSM core", function () {
       "ModuleCore",
       fixture.moduleCore.contract.address
     );
+
     corkConfig = await hre.viem.getContractAt(
       "CorkConfig",
       fixture.config.contract.address
@@ -71,6 +87,7 @@ describe("PSM core", function () {
   describe("issue pair", function () {
     it("should issue new ds", async function () {
       expiryTime = helper.expiry(1e18 * 1000);
+
       const Id = await moduleCore.read.getId([
         fixture.pa.address,
         fixture.ra.address,

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -18,6 +18,13 @@ import UNIV2ROUTER from "./ext-abi/uni-v2-router.json";
 
 const DEVISOR = BigInt(1e18);
 
+export function calculateMinimumLiquidity(amount: bigint) {
+  // 1e16 is the minimum liquidity(10e3)
+  const minLiquidity = amount / BigInt(1e16);
+  
+  return amount - minLiquidity;
+}
+
 export function nowTimestampInSeconds() {
   return Math.floor(Date.now() / 1000);
 }

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -21,8 +21,16 @@ const DEVISOR = BigInt(1e18);
 export function calculateMinimumLiquidity(amount: bigint) {
   // 1e16 is the minimum liquidity(10e3)
   const minLiquidity = amount / BigInt(1e16);
-  
+
   return amount - minLiquidity;
+}
+
+export function encodeAsUQ112x112(amount: bigint) {
+  return amount * BigInt(2 ** 112);
+}
+
+export function decodeUQ112x112(amount: bigint) {
+  return amount / BigInt(2 ** 112);
 }
 
 export function nowTimestampInSeconds() {

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -69,11 +69,11 @@ export async function deployCorkConfig() {
   };
 }
 
-export async function deployModuleCore(factory: Address, config: Address) {
+export async function deployModuleCore(swapAssetFactory: Address, config: Address) {
   const { defaultSigner } = await getSigners();
   const mathLib = await hre.viem.deployContract("MathHelper");
 
-  const contract = await hre.viem.deployContract("ModuleCore", [factory, config], {
+  const contract = await hre.viem.deployContract("ModuleCore", [swapAssetFactory, config], {
     client: {
       wallet: defaultSigner,
     },

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -3,15 +3,18 @@ import {
   loadFixture,
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
-import hre from "hardhat";
+import hre, { viem } from "hardhat";
 import {
   Address,
   formatEther,
+  GetContractReturnType,
   keccak256,
   parseEther,
   verifyTypedData,
   WalletClient,
 } from "viem";
+import UNIV2FACTORY from "@uniswap/v2-core/build/UniswapV2Factory.json";
+import UNIV2ROUTER from "./ext-abi/uni-v2-router.json";
 
 const DEVISOR = BigInt(1e18);
 
@@ -69,21 +72,114 @@ export async function deployCorkConfig() {
   };
 }
 
-export async function deployModuleCore(swapAssetFactory: Address, config: Address) {
-  const { defaultSigner } = await getSigners();
-  const mathLib = await hre.viem.deployContract("MathHelper");
+export async function deployWeth() {
+  const contract = await hre.viem.deployContract("DummyWETH");
 
-  const contract = await hre.viem.deployContract("ModuleCore", [swapAssetFactory, config], {
-    client: {
-      wallet: defaultSigner,
-    },
+  return {
+    contract,
+  };
+}
+
+export async function deployFlashSwapRouter() {
+  const mathLib = await hre.viem.deployContract("SwapperMathLibrary");
+  const contract = await hre.viem.deployContract("RouterState", [], {
     libraries: {
-      MathHelper: mathLib.address,
+      SwapperMathLibrary: mathLib.address,
     },
   });
 
   return {
     contract,
+  };
+}
+
+// will default use the first wallet client
+export async function deployUniV2Factory() {
+  const defaultSigner = await getSigners().then(
+    (signers) => signers.defaultSigner
+  );
+
+  const hash = await defaultSigner.deployContract({
+    abi: UNIV2FACTORY.abi,
+    bytecode: `0x${UNIV2FACTORY.bytecode}`,
+    account: defaultSigner.account,
+    args: [defaultSigner.account.address],
+  });
+
+  const client = await hre.viem.getPublicClient();
+  const receipt = await client.waitForTransactionReceipt({
+    hash,
+  });
+
+  return receipt.contractAddress!;
+}
+
+export async function deployUniV2Router(
+  weth: Address,
+  univ2Factory: Address,
+  router: Address
+) {
+  const defaultSigner = await getSigners().then(
+    (signers) => signers.defaultSigner
+  );
+
+  const hash = await defaultSigner.deployContract({
+    abi: UNIV2ROUTER.abi,
+    bytecode: `0x${UNIV2ROUTER.bytecode}`,
+    account: defaultSigner.account,
+    args: [univ2Factory, weth, router],
+  });
+
+  const client = await hre.viem.getPublicClient();
+  const receipt = await client.waitForTransactionReceipt({
+    hash,
+  });
+
+  return receipt.contractAddress!;
+}
+
+export async function deployModuleCore(
+  swapAssetFactory: Address,
+  config: Address
+) {
+  const { defaultSigner } = await getSigners();
+  const mathLib = await hre.viem.deployContract("MathHelper");
+  const dsFlashSwapRouter = await deployFlashSwapRouter();
+  const univ2Factory = await deployUniV2Factory();
+  const weth = await deployWeth();
+  const univ2Router = await deployUniV2Router(
+    weth.contract.address,
+    univ2Factory,
+    dsFlashSwapRouter.contract.address
+  );
+
+  const contract = await hre.viem.deployContract(
+    "ModuleCore",
+    [
+      swapAssetFactory,
+      univ2Factory,
+      dsFlashSwapRouter.contract.address,
+      univ2Router,
+      config,
+    ],
+    {
+      client: {
+        wallet: defaultSigner,
+      },
+      libraries: {
+        MathHelper: mathLib.address,
+      },
+    }
+  );
+
+  await dsFlashSwapRouter.contract.write.initialize([contract.address]);
+
+  return {
+    contract,
+    univ2Factory,
+    univ2Router,
+    dsFlashSwapRouter,
+    weth,
   };
 }
 
@@ -102,11 +198,9 @@ export async function initializeNewPsmLv(arg: InitializeNewPsmArg) {
   const contract = await hre.viem.getContractAt("ModuleCore", arg.moduleCore);
   const configContract = await hre.viem.getContractAt("CorkConfig", arg.config);
 
-  await configContract.write.setModuleCore([arg.moduleCore],
-    {
-      account: defaultSigner.account,
-    }
-  );
+  await configContract.write.setModuleCore([arg.moduleCore], {
+    account: defaultSigner.account,
+  });
 
   await configContract.write.initializeModuleCore(
     [
@@ -318,18 +412,25 @@ export async function permit(arg: PermitArg) {
 export async function onlymoduleCoreWithFactory() {
   const factory = await deployAssetFactory();
   const config = await deployCorkConfig();
-  const moduleCore = await deployModuleCore(factory.contract.address, config.contract.address);
+  const moduleCore = await deployModuleCore(
+    factory.contract.address,
+    config.contract.address
+  );
   await factory.contract.write.initialize([moduleCore.contract.address]);
 
   return {
     factory,
     moduleCore,
-    config
+    config,
   };
 }
 
 export async function ModuleCoreWithInitializedPsmLv() {
-  const { factory, moduleCore: moduleCore, config } = await onlymoduleCoreWithFactory();
+  const {
+    factory,
+    moduleCore: moduleCore,
+    config,
+  } = await onlymoduleCoreWithFactory();
   const { pa, ra } = await backedAssets();
 
   const fee = parseEther("10");

--- a/test/helper/ext-abi/uni-v2-router.json
+++ b/test/helper/ext-abi/uni-v2-router.json
@@ -1,0 +1,2222 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_factory",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_WETH",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_dsSwapContract",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "WETH",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountADesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidityETH",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "dsSwapContract",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "factory",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAmountIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAmountOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getAmountsIn",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getAmountsOut",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveB",
+          "type": "uint256"
+        }
+      ],
+      "name": "quote",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidityETH",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityETHWithPermit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityWithPermit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapETHForExactTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactETHForTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForETH",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForETHSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountInMax",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapTokensForExactETH",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountInMax",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapTokensForExactTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "evm": {
+    "bytecode": {
+      "linkReferences": {},
+      "object": "60c06040523480156200001157600080fd5b5060405162005a4438038062005a44833981810160405260608110156200003757600080fd5b5080516020820151604090920151606082811b6001600160601b03199081166080529084901b1660a052600080546001600160a01b0319166001600160a01b0392831617815591811692169061589f90620001a59039806101b75280610e7d5280610eb85280610ff552806112c15280611727528061190f5280611e575280611fdb52806120ab52806121b2528061236952806123fe52806126b4528061275b528061283052806129355280612a1d5280612a9e528061314c528061348252806134d8528061350c528061358d52806137a7528061395b52806139f05250806110e752806111ee528061139452806113d55280611580528061181952806118ed5280611ada5280612298528061243d52806125e65280612add5280612e2052806130b252806130f7528061312a528061330752806134b6528061388d5280613a2f52806144b952806144fc528061485d5280614a3e5280614fb9528061509a528061511a525061589f6000f3fe60806040526004361061019a5760003560e01c80638803dbee116100e1578063c45a01551161008a578063ded9382a11610064578063ded9382a14610c11578063e8e3370014610c91578063f305d71914610d1e578063fb3bdb4114610d71576101e0565b8063c45a015514610b30578063caa0c28c14610b45578063d06ca61f14610b5a576101e0565b8063af2979eb116100bb578063af2979eb146109d3578063b6f9de9514610a33578063baa2abde14610ac6576101e0565b80638803dbee146108ba578063ad5c46481461095f578063ad615dec1461099d576101e0565b80634a25d94a11610143578063791ac9471161011d578063791ac9471461074c5780637ff36ab5146107f157806385f8c25914610884576101e0565b80634a25d94a146105825780635b0d5984146106275780635c11d795146106a7576101e0565b80631f00ca74116101745780631f00ca741461039b5780632195995c1461045257806338ed1739146104dd576101e0565b806302751cec146101e5578063054d50d41461025e57806318cbafe5146102a6576101e0565b366101e0573373ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016146101de57fe5b005b600080fd5b3480156101f157600080fd5b50610245600480360360c081101561020857600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135610e04565b6040805192835260208301919091528051918290030190f35b34801561026a57600080fd5b506102946004803603606081101561028157600080fd5b5080359060208101359060400135610f57565b60408051918252519081900360200190f35b3480156102b257600080fd5b5061034b600480360360a08110156102c957600080fd5b8135916020810135918101906060810160408201356401000000008111156102f057600080fd5b82018360208201111561030257600080fd5b8035906020019184602083028401116401000000008311171561032457600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135610f6c565b60408051602080825283518183015283519192839290830191858101910280838360005b8381101561038757818101518382015260200161036f565b505050509050019250505060405180910390f35b3480156103a757600080fd5b5061034b600480360360408110156103be57600080fd5b813591908101906040810160208201356401000000008111156103e057600080fd5b8201836020820111156103f257600080fd5b8035906020019184602083028401116401000000008311171561041457600080fd5b91908080602002602001604051908101604052809392919081815260200183836020028082843760009201919091525092955061138d945050505050565b34801561045e57600080fd5b50610245600480360361016081101561047657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c08101359060e081013515159060ff61010082013516906101208101359061014001356113cb565b3480156104e957600080fd5b5061034b600480360360a081101561050057600080fd5b81359160208101359181019060608101604082013564010000000081111561052757600080fd5b82018360208201111561053957600080fd5b8035906020019184602083028401116401000000008311171561055b57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611509565b34801561058e57600080fd5b5061034b600480360360a08110156105a557600080fd5b8135916020810135918101906060810160408201356401000000008111156105cc57600080fd5b8201836020820111156105de57600080fd5b8035906020019184602083028401116401000000008311171561060057600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561169e565b34801561063357600080fd5b50610294600480360361014081101561064b57600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e082013516906101008101359061012001356118e5565b3480156106b357600080fd5b506101de600480360360a08110156106ca57600080fd5b8135916020810135918101906060810160408201356401000000008111156106f157600080fd5b82018360208201111561070357600080fd5b8035906020019184602083028401116401000000008311171561072557600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611a37565b34801561075857600080fd5b506101de600480360360a081101561076f57600080fd5b81359160208101359181019060608101604082013564010000000081111561079657600080fd5b8201836020820111156107a857600080fd5b803590602001918460208302840111640100000000831117156107ca57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611dd0565b61034b6004803603608081101561080757600080fd5b8135919081019060408101602082013564010000000081111561082957600080fd5b82018360208201111561083b57600080fd5b8035906020019184602083028401116401000000008311171561085d57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561213e565b34801561089057600080fd5b50610294600480360360608110156108a757600080fd5b5080359060208101359060400135612562565b3480156108c657600080fd5b5061034b600480360360a08110156108dd57600080fd5b81359160208101359181019060608101604082013564010000000081111561090457600080fd5b82018360208201111561091657600080fd5b8035906020019184602083028401116401000000008311171561093857600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561256f565b34801561096b57600080fd5b506109746126b2565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b3480156109a957600080fd5b50610294600480360360608110156109c057600080fd5b50803590602081013590604001356126d6565b3480156109df57600080fd5b50610294600480360360c08110156109f657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a001356126e3565b6101de60048036036080811015610a4957600080fd5b81359190810190604081016020820135640100000000811115610a6b57600080fd5b820183602082011115610a7d57600080fd5b80359060200191846020830284011164010000000083111715610a9f57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff81351690602001356128c3565b348015610ad257600080fd5b50610245600480360360e0811015610ae957600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c00135612da6565b348015610b3c57600080fd5b506109746130b0565b348015610b5157600080fd5b506109746130d4565b348015610b6657600080fd5b5061034b60048036036040811015610b7d57600080fd5b81359190810190604081016020820135640100000000811115610b9f57600080fd5b820183602082011115610bb157600080fd5b80359060200191846020830284011164010000000083111715610bd357600080fd5b9190808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152509295506130f0945050505050565b348015610c1d57600080fd5b506102456004803603610140811015610c3557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e08201351690610100810135906101200135613120565b348015610c9d57600080fd5b50610d006004803603610100811015610cb557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359160c0820135169060e00135613278565b60408051938452602084019290925282820152519081900360600190f35b610d00600480360360c0811015610d3457600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135613407565b61034b60048036036080811015610d8757600080fd5b81359190810190604081016020820135640100000000811115610da957600080fd5b820183602082011115610dbb57600080fd5b80359060200191846020830284011164010000000083111715610ddd57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135613733565b6000808242811015610e7757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b610ea6897f00000000000000000000000000000000000000000000000000000000000000008a8a8a308a612da6565b9093509150610eb6898685613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b158015610f2957600080fd5b505af1158015610f3d573d6000803e3d6000fd5b50505050610f4b8583613d4d565b50965096945050505050565b6000610f64848484613e8a565b949350505050565b60608142811015610fde57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061104357fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16146110e257604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6111497f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b613fcd565b9150868260018451038151811061115c57fe5b602002602001015110156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b611280868660008181106111cb57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16336112667f00000000000000000000000000000000000000000000000000000000000000008a8a600081811061121a57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168b8b600181811061124457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16614135565b8560008151811061127357fe5b6020026020010151614220565b6112bf828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152503092506143f0915050565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d8360018551038151811061130b57fe5b60200260200101516040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561134957600080fd5b505af115801561135d573d6000803e3d6000fd5b50505050611382848360018551038151811061137557fe5b6020026020010151613d4d565b509695505050505050565b60606113c27f000000000000000000000000000000000000000000000000000000000000000084846113bd613fae565b614677565b90505b92915050565b60008060006113fb7f00000000000000000000000000000000000000000000000000000000000000008f8f614135565b905060008761140a578c61142c565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b1580156114c857600080fd5b505af11580156114dc573d6000803e3d6000fd5b505050506114ef8f8f8f8f8f8f8f612da6565b809450819550505050509b509b9950505050505050505050565b6060814281101561157b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6115dd7f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b915086826001845103815181106115f057fe5b6020026020010151101561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b61165f868660008181106111cb57fe5b611382828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b6060814281101561171057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061177557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461181457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6118767f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061188657fe5b602002602001015111156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b6000806119337f00000000000000000000000000000000000000000000000000000000000000008d7f0000000000000000000000000000000000000000000000000000000000000000614135565b9050600086611942578b611964565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018b905260ff8916608482015260a4810188905260c48101879052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b158015611a0057600080fd5b505af1158015611a14573d6000803e3d6000fd5b50505050611a268d8d8d8d8d8d6126e3565b9d9c50505050505050505050505050565b8042811015611aa757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b611b3685856000818110611ab757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1633611b307f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168a8a600181811061124457fe5b8a614220565b600085857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611b6657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231856040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611bff57600080fd5b505afa158015611c13573d6000803e3d6000fd5b505050506040513d6020811015611c2957600080fd5b50516040805160208881028281018201909352888252929350611c6b929091899189918291850190849080828437600092019190915250889250614806915050565b86611d6f8288887fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611c9e57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b505afa158015611d4b573d6000803e3d6000fd5b505050506040513d6020811015611d6157600080fd5b50519063ffffffff614b9916565b1015611dc6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b5050505050505050565b8042811015611e4057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001685857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611ea557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614611f4457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b611f5485856000818110611ab757fe5b611f92858580806020026020016040519081016040528093929190818152602001838360200280828437600092019190915250309250614806915050565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905160009173ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016916370a0823191602480820192602092909190829003018186803b15801561202257600080fd5b505afa158015612036573d6000803e3d6000fd5b505050506040513d602081101561204c57600080fd5b50519050868110156120a9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d826040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561211c57600080fd5b505af1158015612130573d6000803e3d6000fd5b50505050611dc68482613d4d565b606081428110156121b057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106121f457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461229357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6122f57f0000000000000000000000000000000000000000000000000000000000000000348888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b9150868260018451038151811061230857fe5b60200260200101511015612367576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106123b057fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156123e357600080fd5b505af11580156123f7573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb6124697f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b8460008151811061247657fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b1580156124e757600080fd5b505af11580156124fb573d6000803e3d6000fd5b505050506040513d602081101561251157600080fd5b505161251957fe5b612558828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b5095945050505050565b6000610f64848484614c0b565b606081428110156125e157604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6126437f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061265357fe5b6020026020010151111561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000081565b6000610f64848484614d2f565b6000814281101561275557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b612784887f00000000000000000000000000000000000000000000000000000000000000008989893089612da6565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905191945061282e92508a91879173ffffffffffffffffffffffffffffffffffffffff8416916370a0823191602480820192602092909190829003018186803b1580156127fd57600080fd5b505afa158015612811573d6000803e3d6000fd5b505050506040513d602081101561282757600080fd5b5051613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b1580156128a157600080fd5b505af11580156128b5573d6000803e3d6000fd5b505050506113828483613d4d565b804281101561293357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff168585600081811061297757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614612a1657604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b60003490507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0826040518263ffffffff1660e01b81526004016000604051808303818588803b158015612a8357600080fd5b505af1158015612a97573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb612b097f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b836040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015612b7357600080fd5b505af1158015612b87573d6000803e3d6000fd5b505050506040513d6020811015612b9d57600080fd5b5051612ba557fe5b600086867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612bd557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231866040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015612c6e57600080fd5b505afa158015612c82573d6000803e3d6000fd5b505050506040513d6020811015612c9857600080fd5b50516040805160208981028281018201909352898252929350612cda9290918a918a918291850190849080828437600092019190915250899250614806915050565b87611d6f8289897fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612d0d57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231896040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b6000808242811015612e1957604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6000612e467f00000000000000000000000000000000000000000000000000000000000000008c8c614135565b604080517f23b872dd00000000000000000000000000000000000000000000000000000000815233600482015273ffffffffffffffffffffffffffffffffffffffff831660248201819052604482018d9052915192935090916323b872dd916064808201926020929091908290030181600087803b158015612ec757600080fd5b505af1158015612edb573d6000803e3d6000fd5b505050506040513d6020811015612ef157600080fd5b5050604080517f89afcb4400000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015282516000938493928616926389afcb44926024808301939282900301818787803b158015612f6457600080fd5b505af1158015612f78573d6000803e3d6000fd5b505050506040513d6040811015612f8e57600080fd5b50805160209091015190925090506000612fa88e8e614e0f565b5090508073ffffffffffffffffffffffffffffffffffffffff168e73ffffffffffffffffffffffffffffffffffffffff1614612fe5578183612fe8565b82825b90975095508a871015613046576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b8986101561309f576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b505050505097509795505050505050565b7f000000000000000000000000000000000000000000000000000000000000000081565b60005473ffffffffffffffffffffffffffffffffffffffff1681565b60606113c27f00000000000000000000000000000000000000000000000000000000000000008484611144613fae565b60008060006131707f00000000000000000000000000000000000000000000000000000000000000008e7f0000000000000000000000000000000000000000000000000000000000000000614135565b905060008761317f578c6131a1565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b15801561323d57600080fd5b505af1158015613251573d6000803e3d6000fd5b505050506132638e8e8e8e8e8e610e04565b909f909e509c50505050505050505050505050565b600080600083428110156132ed57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6132fb8c8c8c8c8c8c614f62565b9094509250600061332d7f00000000000000000000000000000000000000000000000000000000000000008e8e614135565b905061333b8d338388614220565b6133478c338387614220565b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156133c657600080fd5b505af11580156133da573d6000803e3d6000fd5b505050506040513d60208110156133f057600080fd5b5051949d939c50939a509198505050505050505050565b6000806000834281101561347c57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6134aa8a7f00000000000000000000000000000000000000000000000000000000000000008b348c8c614f62565b909450925060006134fc7f00000000000000000000000000000000000000000000000000000000000000008c7f0000000000000000000000000000000000000000000000000000000000000000614135565b905061350a8b338388614220565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0856040518263ffffffff1660e01b81526004016000604051808303818588803b15801561357257600080fd5b505af1158015613586573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb82866040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b15801561363257600080fd5b505af1158015613646573d6000803e3d6000fd5b505050506040513d602081101561365c57600080fd5b505161366457fe5b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156136e357600080fd5b505af11580156136f7573d6000803e3d6000fd5b505050506040513d602081101561370d57600080fd5b50519250348410156137255761372533853403613d4d565b505096509650969350505050565b606081428110156137a557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106137e957fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461388857604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6138ea7f0000000000000000000000000000000000000000000000000000000000000000888888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b915034826000815181106138fa57fe5b60200260200101511115613959576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106139a257fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156139d557600080fd5b505af11580156139e9573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb613a5b7f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b84600081518110613a6857fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015613ad957600080fd5b505af1158015613aed573d6000803e3d6000fd5b505050506040513d6020811015613b0357600080fd5b5051613b0b57fe5b613b4a828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b81600081518110613b5757fe5b6020026020010151341115612558576125583383600081518110613b7757fe5b60200260200101513403613d4d565b6040805173ffffffffffffffffffffffffffffffffffffffff8481166024830152604480830185905283518084039091018152606490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167fa9059cbb00000000000000000000000000000000000000000000000000000000178152925182516000946060949389169392918291908083835b60208310613c5c57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613c1f565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114613cbe576040519150601f19603f3d011682016040523d82523d6000602084013e613cc3565b606091505b5091509150818015613cf1575080511580613cf15750808060200190516020811015613cee57600080fd5b50515b613d46576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602d815260200180615812602d913960400191505060405180910390fd5b5050505050565b6040805160008082526020820190925273ffffffffffffffffffffffffffffffffffffffff84169083906040518082805190602001908083835b60208310613dc457805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613d87565b6001836020036101000a03801982511681845116808217855250505050505090500191505060006040518083038185875af1925050503d8060008114613e26576040519150601f19603f3d011682016040523d82523d6000602084013e613e2b565b606091505b5050905080613e85576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260348152602001806156ce6034913960400191505060405180910390fd5b505050565b6000808411613ee4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b600083118015613ef45750600082115b613f49576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000613f5d856103e563ffffffff61526316565b90506000613f71828563ffffffff61526316565b90506000613f9783613f8b886103e863ffffffff61526316565b9063ffffffff6152e916565b9050808281613fa257fe5b04979650505050505050565b60005473ffffffffffffffffffffffffffffffffffffffff1633141590565b606060028351101561404057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561405857600080fd5b50604051908082528060200260200182016040528015614082578160200160208202803683370190505b509050838160008151811061409357fe5b60200260200101818152505060005b600184510381101561412c576000806140e5888785815181106140c157fe5b60200260200101518886600101815181106140d857fe5b602002602001015161535b565b915091506141088484815181106140f857fe5b6020026020010151838388615443565b84846001018151811061411757fe5b602090810291909101015250506001016140a2565b50949350505050565b60008060006141448585614e0f565b604080517fffffffffffffffffffffffffffffffffffffffff000000000000000000000000606094851b811660208084019190915293851b81166034830152825160288184030181526048830184528051908501207fff0000000000000000000000000000000000000000000000000000000000000060688401529a90941b9093166069840152607d8301989098527f96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f609d808401919091528851808403909101815260bd909201909752805196019590952095945050505050565b6040805173ffffffffffffffffffffffffffffffffffffffff85811660248301528481166044830152606480830185905283518084039091018152608490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167f23b872dd0000000000000000000000000000000000000000000000000000000017815292518251600094606094938a169392918291908083835b602083106142fe57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe090920191602091820191016142c1565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114614360576040519150601f19603f3d011682016040523d82523d6000602084013e614365565b606091505b5091509150818015614393575080511580614393575080806020019051602081101561439057600080fd5b50515b6143e8576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252603181526020018061569d6031913960400191505060405180910390fd5b505050505050565b60005b60018351038110156146715760008084838151811061440e57fe5b602002602001015185846001018151811061442557fe5b602002602001015191509150600061443d8383614e0f565b509050600087856001018151811061445157fe5b602002602001015190506000808373ffffffffffffffffffffffffffffffffffffffff168673ffffffffffffffffffffffffffffffffffffffff16146144995782600061449d565b6000835b91509150600060028a510388106144b457886144f5565b6144f57f0000000000000000000000000000000000000000000000000000000000000000878c8b600201815181106144e857fe5b6020026020010151614135565b90506145227f00000000000000000000000000000000000000000000000000000000000000008888614135565b73ffffffffffffffffffffffffffffffffffffffff1663022c0d9f84848460006040519080825280601f01601f19166020018201604052801561456c576020820181803683370190505b506040518563ffffffff1660e01b8152600401808581526020018481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200180602001828103825283818151815260200191508051906020019080838360005b838110156145f75781810151838201526020016145df565b50505050905090810190601f1680156146245780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b15801561464657600080fd5b505af115801561465a573d6000803e3d6000fd5b5050600190990198506143f3975050505050505050565b50505050565b60606002835110156146ea57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561470257600080fd5b5060405190808252806020026020018201604052801561472c578160200160208202803683370190505b509050838160018351038151811061474057fe5b602090810291909101015282517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff015b801561412c576000806147a08887600186038151811061478c57fe5b60200260200101518886815181106140d857fe5b915091506147c38484815181106147b357fe5b6020026020010151838388615571565b8460018503815181106147d257fe5b602090810291909101015250507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01614770565b60005b6001835103811015613e855760008084838151811061482457fe5b602002602001015185846001018151811061483b57fe5b60200260200101519150915060006148538383614e0f565b50905060006148837f00000000000000000000000000000000000000000000000000000000000000008585614135565b90506000806000808473ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156148d157600080fd5b505afa1580156148e5573d6000803e3d6000fd5b505050506040513d60608110156148fb57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905060008073ffffffffffffffffffffffffffffffffffffffff8a811690891614614945578284614948565b83835b915091506149cd828b73ffffffffffffffffffffffffffffffffffffffff166370a082318a6040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b95506149da868383613e8a565b9450505050506000808573ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614614a1e57826000614a22565b6000835b91509150600060028c51038a10614a39578a614a6d565b614a6d7f0000000000000000000000000000000000000000000000000000000000000000898e8d600201815181106144e857fe5b60408051600080825260208201928390527f022c0d9f000000000000000000000000000000000000000000000000000000008352602482018781526044830187905273ffffffffffffffffffffffffffffffffffffffff8086166064850152608060848501908152845160a48601819052969750908c169563022c0d9f958a958a958a9591949193919260c486019290918190849084905b83811015614b1d578181015183820152602001614b05565b50505050905090810190601f168015614b4a5780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b158015614b6c57600080fd5b505af1158015614b80573d6000803e3d6000fd5b50506001909b019a506148099950505050505050505050565b808203828111156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601560248201527f64732d6d6174682d7375622d756e646572666c6f770000000000000000000000604482015290519081900360640190fd5b6000808411614c65576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b600083118015614c755750600082115b614cca576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000614cee6103e8614ce2868863ffffffff61526316565b9063ffffffff61526316565b90506000614d086103e5614ce2868963ffffffff614b9916565b9050614d256001828481614d1857fe5b049063ffffffff6152e916565b9695505050505050565b6000808411614d89576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157756025913960400191505060405180910390fd5b600083118015614d995750600082115b614dee576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b82614dff858463ffffffff61526316565b81614e0657fe5b04949350505050565b6000808273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff161415614e97576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157026025913960400191505060405180910390fd5b8273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff1610614ed1578284614ed4565b83835b909250905073ffffffffffffffffffffffffffffffffffffffff8216614f5b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a205a45524f5f414444524553530000604482015290519081900360640190fd5b9250929050565b604080517fe6a4390500000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015287811660248301529151600092839283927f00000000000000000000000000000000000000000000000000000000000000009092169163e6a4390591604480820192602092909190829003018186803b15801561500257600080fd5b505afa158015615016573d6000803e3d6000fd5b505050506040513d602081101561502c57600080fd5b505173ffffffffffffffffffffffffffffffffffffffff16141561511257604080517fc9c6539600000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff8a81166004830152898116602483015291517f00000000000000000000000000000000000000000000000000000000000000009092169163c9c65396916044808201926020929091908290030181600087803b1580156150e557600080fd5b505af11580156150f9573d6000803e3d6000fd5b505050506040513d602081101561510f57600080fd5b50505b6000806151407f00000000000000000000000000000000000000000000000000000000000000008b8b61535b565b91509150816000148015615152575080155b1561516257879350869250615256565b600061516f898484614d2f565b90508781116151dc57858110156151d1576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b889450925082615254565b60006151e9898486614d2f565b9050898111156151f557fe5b8781101561524e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b94508793505b505b5050965096945050505050565b600081158061527e5750508082028282828161527b57fe5b04145b6113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6d756c2d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b808201828110156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6164642d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b600080600061536a8585614e0f565b50905060008061537b888888614135565b73ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156153c057600080fd5b505afa1580156153d4573d6000803e3d6000fd5b505050506040513d60608110156153ea57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905073ffffffffffffffffffffffffffffffffffffffff87811690841614615431578082615434565b81815b90999098509650505050505050565b6000811561545d57615456858585613e8a565b9050610f64565b600085116154b6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b6000841180156154c65750600083115b61551b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061552f866103e863ffffffff61526316565b90506000615543828663ffffffff61526316565b90506000615559876103e863ffffffff61526316565b905080828161556457fe5b0498975050505050505050565b6000811561558457615456858585614c0b565b600085116155dd576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b6000841180156155ed5750600083115b615642576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061565a6103e8614ce2878963ffffffff61526316565b90506000613f97856103e863ffffffff6152631656fe556e697377617056324c6962726172793a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a7472616e7366657246726f6d3a207472616e7366657246726f6d206661696c65645472616e7366657248656c7065723a3a736166655472616e736665724554483a20455448207472616e73666572206661696c6564556e697377617056324c6962726172793a204944454e544943414c5f414444524553534553556e69737761705632526f757465723a20494e53554646494349454e545f425f414d4f554e54556e697377617056324c6962726172793a20494e53554646494349454e545f4c4951554944495459556e697377617056324c6962726172793a20494e53554646494349454e545f414d4f554e54556e69737761705632526f757465723a204558434553534956455f494e5055545f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f415f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a736166655472616e736665723a207472616e73666572206661696c6564556e697377617056324c6962726172793a20494e53554646494349454e545f494e5055545f414d4f554e54a2646970667358221220727ddc3491766f9b8dc46e1c4bafbfdb094815ade2af57a4703d38a9b8e4709c64736f6c63430006060033",
+      "opcodes": "PUSH1 0xC0 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH3 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD PUSH3 0x5A44 CODESIZE SUB DUP1 PUSH3 0x5A44 DUP4 CODECOPY DUP2 DUP2 ADD PUSH1 0x40 MSTORE PUSH1 0x60 DUP2 LT ISZERO PUSH3 0x37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 DUP3 ADD MLOAD PUSH1 0x40 SWAP1 SWAP3 ADD MLOAD PUSH1 0x60 DUP3 DUP2 SHL PUSH1 0x1 PUSH1 0x1 PUSH1 0x60 SHL SUB NOT SWAP1 DUP2 AND PUSH1 0x80 MSTORE SWAP1 DUP5 SWAP1 SHL AND PUSH1 0xA0 MSTORE PUSH1 0x0 DUP1 SLOAD PUSH1 0x1 PUSH1 0x1 PUSH1 0xA0 SHL SUB NOT AND PUSH1 0x1 PUSH1 0x1 PUSH1 0xA0 SHL SUB SWAP3 DUP4 AND OR DUP2 SSTORE SWAP2 DUP2 AND SWAP3 AND SWAP1 PUSH2 0x589F SWAP1 PUSH3 0x1A5 SWAP1 CODECOPY DUP1 PUSH2 0x1B7 MSTORE DUP1 PUSH2 0xE7D MSTORE DUP1 PUSH2 0xEB8 MSTORE DUP1 PUSH2 0xFF5 MSTORE DUP1 PUSH2 0x12C1 MSTORE DUP1 PUSH2 0x1727 MSTORE DUP1 PUSH2 0x190F MSTORE DUP1 PUSH2 0x1E57 MSTORE DUP1 PUSH2 0x1FDB MSTORE DUP1 PUSH2 0x20AB MSTORE DUP1 PUSH2 0x21B2 MSTORE DUP1 PUSH2 0x2369 MSTORE DUP1 PUSH2 0x23FE MSTORE DUP1 PUSH2 0x26B4 MSTORE DUP1 PUSH2 0x275B MSTORE DUP1 PUSH2 0x2830 MSTORE DUP1 PUSH2 0x2935 MSTORE DUP1 PUSH2 0x2A1D MSTORE DUP1 PUSH2 0x2A9E MSTORE DUP1 PUSH2 0x314C MSTORE DUP1 PUSH2 0x3482 MSTORE DUP1 PUSH2 0x34D8 MSTORE DUP1 PUSH2 0x350C MSTORE DUP1 PUSH2 0x358D MSTORE DUP1 PUSH2 0x37A7 MSTORE DUP1 PUSH2 0x395B MSTORE DUP1 PUSH2 0x39F0 MSTORE POP DUP1 PUSH2 0x10E7 MSTORE DUP1 PUSH2 0x11EE MSTORE DUP1 PUSH2 0x1394 MSTORE DUP1 PUSH2 0x13D5 MSTORE DUP1 PUSH2 0x1580 MSTORE DUP1 PUSH2 0x1819 MSTORE DUP1 PUSH2 0x18ED MSTORE DUP1 PUSH2 0x1ADA MSTORE DUP1 PUSH2 0x2298 MSTORE DUP1 PUSH2 0x243D MSTORE DUP1 PUSH2 0x25E6 MSTORE DUP1 PUSH2 0x2ADD MSTORE DUP1 PUSH2 0x2E20 MSTORE DUP1 PUSH2 0x30B2 MSTORE DUP1 PUSH2 0x30F7 MSTORE DUP1 PUSH2 0x312A MSTORE DUP1 PUSH2 0x3307 MSTORE DUP1 PUSH2 0x34B6 MSTORE DUP1 PUSH2 0x388D MSTORE DUP1 PUSH2 0x3A2F MSTORE DUP1 PUSH2 0x44B9 MSTORE DUP1 PUSH2 0x44FC MSTORE DUP1 PUSH2 0x485D MSTORE DUP1 PUSH2 0x4A3E MSTORE DUP1 PUSH2 0x4FB9 MSTORE DUP1 PUSH2 0x509A MSTORE DUP1 PUSH2 0x511A MSTORE POP PUSH2 0x589F PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE PUSH1 0x4 CALLDATASIZE LT PUSH2 0x19A JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x8803DBEE GT PUSH2 0xE1 JUMPI DUP1 PUSH4 0xC45A0155 GT PUSH2 0x8A JUMPI DUP1 PUSH4 0xDED9382A GT PUSH2 0x64 JUMPI DUP1 PUSH4 0xDED9382A EQ PUSH2 0xC11 JUMPI DUP1 PUSH4 0xE8E33700 EQ PUSH2 0xC91 JUMPI DUP1 PUSH4 0xF305D719 EQ PUSH2 0xD1E JUMPI DUP1 PUSH4 0xFB3BDB41 EQ PUSH2 0xD71 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0xC45A0155 EQ PUSH2 0xB30 JUMPI DUP1 PUSH4 0xCAA0C28C EQ PUSH2 0xB45 JUMPI DUP1 PUSH4 0xD06CA61F EQ PUSH2 0xB5A JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0xAF2979EB GT PUSH2 0xBB JUMPI DUP1 PUSH4 0xAF2979EB EQ PUSH2 0x9D3 JUMPI DUP1 PUSH4 0xB6F9DE95 EQ PUSH2 0xA33 JUMPI DUP1 PUSH4 0xBAA2ABDE EQ PUSH2 0xAC6 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x8803DBEE EQ PUSH2 0x8BA JUMPI DUP1 PUSH4 0xAD5C4648 EQ PUSH2 0x95F JUMPI DUP1 PUSH4 0xAD615DEC EQ PUSH2 0x99D JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x4A25D94A GT PUSH2 0x143 JUMPI DUP1 PUSH4 0x791AC947 GT PUSH2 0x11D JUMPI DUP1 PUSH4 0x791AC947 EQ PUSH2 0x74C JUMPI DUP1 PUSH4 0x7FF36AB5 EQ PUSH2 0x7F1 JUMPI DUP1 PUSH4 0x85F8C259 EQ PUSH2 0x884 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x4A25D94A EQ PUSH2 0x582 JUMPI DUP1 PUSH4 0x5B0D5984 EQ PUSH2 0x627 JUMPI DUP1 PUSH4 0x5C11D795 EQ PUSH2 0x6A7 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x1F00CA74 GT PUSH2 0x174 JUMPI DUP1 PUSH4 0x1F00CA74 EQ PUSH2 0x39B JUMPI DUP1 PUSH4 0x2195995C EQ PUSH2 0x452 JUMPI DUP1 PUSH4 0x38ED1739 EQ PUSH2 0x4DD JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x2751CEC EQ PUSH2 0x1E5 JUMPI DUP1 PUSH4 0x54D50D4 EQ PUSH2 0x25E JUMPI DUP1 PUSH4 0x18CBAFE5 EQ PUSH2 0x2A6 JUMPI PUSH2 0x1E0 JUMP JUMPDEST CALLDATASIZE PUSH2 0x1E0 JUMPI CALLER PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND EQ PUSH2 0x1DE JUMPI INVALID JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x1F1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0x208 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0xE04 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP3 DUP4 MSTORE PUSH1 0x20 DUP4 ADD SWAP2 SWAP1 SWAP2 MSTORE DUP1 MLOAD SWAP2 DUP3 SWAP1 SUB ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x26A JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x281 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0xF57 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP2 DUP3 MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x20 ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x2B2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x2C9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x2F0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x302 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x324 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0xF6C JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP1 DUP3 MSTORE DUP4 MLOAD DUP2 DUP4 ADD MSTORE DUP4 MLOAD SWAP2 SWAP3 DUP4 SWAP3 SWAP1 DUP4 ADD SWAP2 DUP6 DUP2 ADD SWAP2 MUL DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x387 JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x36F JUMP JUMPDEST POP POP POP POP SWAP1 POP ADD SWAP3 POP POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x3A7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x40 DUP2 LT ISZERO PUSH2 0x3BE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x3E0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x3F2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x414 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP1 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP SWAP3 SWAP6 POP PUSH2 0x138D SWAP5 POP POP POP POP POP JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x45E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x160 DUP2 LT ISZERO PUSH2 0x476 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 SWAP2 AND SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xE0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH2 0x100 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x120 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x140 ADD CALLDATALOAD PUSH2 0x13CB JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x4E9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x500 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x527 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x539 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x55B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1509 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x58E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x5A5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x5CC JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x5DE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x600 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x169E JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x633 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x140 DUP2 LT ISZERO PUSH2 0x64B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH1 0xE0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x100 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x120 ADD CALLDATALOAD PUSH2 0x18E5 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x6B3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x6CA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x6F1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x703 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x725 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1A37 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x758 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x76F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x796 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x7A8 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x7CA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1DD0 JUMP JUMPDEST PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0x807 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x829 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x83B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x85D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x213E JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x890 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x8A7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0x2562 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x8C6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x8DD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x904 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x916 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x938 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x256F JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x96B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x26B2 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP1 SWAP3 AND DUP3 MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x20 ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x9A9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x9C0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0x26D6 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x9DF JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0x9F6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0x26E3 JUMP JUMPDEST PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0xA49 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xA6B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xA7D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xA9F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x28C3 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xAD2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xE0 DUP2 LT ISZERO PUSH2 0xAE9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 SWAP2 AND SWAP1 PUSH1 0xC0 ADD CALLDATALOAD PUSH2 0x2DA6 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB3C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x30B0 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB51 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x30D4 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB66 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x40 DUP2 LT ISZERO PUSH2 0xB7D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xB9F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xBB1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xBD3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP1 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP SWAP3 SWAP6 POP PUSH2 0x30F0 SWAP5 POP POP POP POP POP JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xC1D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x140 DUP2 LT ISZERO PUSH2 0xC35 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH1 0xE0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x100 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x120 ADD CALLDATALOAD PUSH2 0x3120 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xC9D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0xD00 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x100 DUP2 LT ISZERO PUSH2 0xCB5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0xC0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xE0 ADD CALLDATALOAD PUSH2 0x3278 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP4 DUP5 MSTORE PUSH1 0x20 DUP5 ADD SWAP3 SWAP1 SWAP3 MSTORE DUP3 DUP3 ADD MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x60 ADD SWAP1 RETURN JUMPDEST PUSH2 0xD00 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0xD34 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0x3407 JUMP JUMPDEST PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0xD87 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xDA9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xDBB JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xDDD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x3733 JUMP JUMPDEST PUSH1 0x0 DUP1 DUP3 TIMESTAMP DUP2 LT ISZERO PUSH2 0xE77 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0xEA6 DUP10 PUSH32 0x0 DUP11 DUP11 DUP11 ADDRESS DUP11 PUSH2 0x2DA6 JUMP JUMPDEST SWAP1 SWAP4 POP SWAP2 POP PUSH2 0xEB6 DUP10 DUP7 DUP6 PUSH2 0x3B86 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0xF29 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0xF3D JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0xF4B DUP6 DUP4 PUSH2 0x3D4D JUMP JUMPDEST POP SWAP7 POP SWAP7 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x3E8A JUMP JUMPDEST SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0xFDE JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1043 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x10E2 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1149 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST PUSH2 0x3FCD JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x115C JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x11BB JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH2 0x1280 DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x11CB JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER PUSH2 0x1266 PUSH32 0x0 DUP11 DUP11 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x121A JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP12 DUP12 PUSH1 0x1 DUP2 DUP2 LT PUSH2 0x1244 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH2 0x4135 JUMP JUMPDEST DUP6 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x1273 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x4220 JUMP JUMPDEST PUSH2 0x12BF DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP ADDRESS SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x1 DUP6 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x130B JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1349 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x135D JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1382 DUP5 DUP4 PUSH1 0x1 DUP6 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x1375 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x3D4D JUMP JUMPDEST POP SWAP7 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x60 PUSH2 0x13C2 PUSH32 0x0 DUP5 DUP5 PUSH2 0x13BD PUSH2 0x3FAE JUMP JUMPDEST PUSH2 0x4677 JUMP JUMPDEST SWAP1 POP JUMPDEST SWAP3 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x13FB PUSH32 0x0 DUP16 DUP16 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP8 PUSH2 0x140A JUMPI DUP13 PUSH2 0x142C JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP13 SWAP1 MSTORE PUSH1 0xFF DUP11 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP10 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP9 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x14C8 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x14DC JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x14EF DUP16 DUP16 DUP16 DUP16 DUP16 DUP16 DUP16 PUSH2 0x2DA6 JUMP JUMPDEST DUP1 SWAP5 POP DUP2 SWAP6 POP POP POP POP POP SWAP12 POP SWAP12 SWAP10 POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x157B JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x15DD PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x15F0 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x164F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH2 0x165F DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x11CB JUMPI INVALID JUMPDEST PUSH2 0x1382 DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1710 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1775 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x1814 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1876 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x1886 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x11BB JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 PUSH2 0x1933 PUSH32 0x0 DUP14 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP7 PUSH2 0x1942 JUMPI DUP12 PUSH2 0x1964 JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP12 SWAP1 MSTORE PUSH1 0xFF DUP10 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP9 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP8 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1A00 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x1A14 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1A26 DUP14 DUP14 DUP14 DUP14 DUP14 DUP14 PUSH2 0x26E3 JUMP JUMPDEST SWAP14 SWAP13 POP POP POP POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1AA7 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1B36 DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1AB7 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER PUSH2 0x1B30 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP11 DUP11 PUSH1 0x1 DUP2 DUP2 LT PUSH2 0x1244 JUMPI INVALID JUMPDEST DUP11 PUSH2 0x4220 JUMP JUMPDEST PUSH1 0x0 DUP6 DUP6 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1B66 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP6 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1BFF JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x1C13 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x1C29 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP9 DUP2 MUL DUP3 DUP2 ADD DUP3 ADD SWAP1 SWAP4 MSTORE DUP9 DUP3 MSTORE SWAP3 SWAP4 POP PUSH2 0x1C6B SWAP3 SWAP1 SWAP2 DUP10 SWAP2 DUP10 SWAP2 DUP3 SWAP2 DUP6 ADD SWAP1 DUP5 SWAP1 DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP9 SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST DUP7 PUSH2 0x1D6F DUP3 DUP9 DUP9 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1C9E JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x1D4B JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x1D61 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x4B99 AND JUMP JUMPDEST LT ISZERO PUSH2 0x1DC6 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1E40 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP6 DUP6 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1EA5 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x1F44 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1F54 DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1AB7 JUMPI INVALID JUMPDEST PUSH2 0x1F92 DUP6 DUP6 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP ADDRESS SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x70A0823100000000000000000000000000000000000000000000000000000000 DUP2 MSTORE ADDRESS PUSH1 0x4 DUP3 ADD MSTORE SWAP1 MLOAD PUSH1 0x0 SWAP2 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND SWAP2 PUSH4 0x70A08231 SWAP2 PUSH1 0x24 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2022 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2036 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x204C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP1 POP DUP7 DUP2 LT ISZERO PUSH2 0x20A9 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP3 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x211C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2130 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1DC6 DUP5 DUP3 PUSH2 0x3D4D JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x21B0 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x21F4 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2293 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x22F5 PUSH32 0x0 CALLVALUE DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x2308 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x2367 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x23B0 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x23E3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x23F7 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x2469 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP5 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x2476 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x24E7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x24FB JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2511 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x2519 JUMPI INVALID JUMPDEST PUSH2 0x2558 DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST POP SWAP6 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x4C0B JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x25E1 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x2643 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x2653 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x164F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 DUP2 JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x4D2F JUMP JUMPDEST PUSH1 0x0 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2755 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x2784 DUP9 PUSH32 0x0 DUP10 DUP10 DUP10 ADDRESS DUP10 PUSH2 0x2DA6 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x70A0823100000000000000000000000000000000000000000000000000000000 DUP2 MSTORE ADDRESS PUSH1 0x4 DUP3 ADD MSTORE SWAP1 MLOAD SWAP2 SWAP5 POP PUSH2 0x282E SWAP3 POP DUP11 SWAP2 DUP8 SWAP2 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0x70A08231 SWAP2 PUSH1 0x24 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x27FD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2811 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2827 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3B86 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x28A1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x28B5 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1382 DUP5 DUP4 PUSH2 0x3D4D JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2933 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x2977 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2A16 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 CALLVALUE SWAP1 POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP3 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2A83 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2A97 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x2B09 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP4 PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2B73 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2B87 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2B9D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x2BA5 JUMPI INVALID JUMPDEST PUSH1 0x0 DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x2BD5 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP7 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2C6E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2C82 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2C98 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP10 DUP2 MUL DUP3 DUP2 ADD DUP3 ADD SWAP1 SWAP4 MSTORE DUP10 DUP3 MSTORE SWAP3 SWAP4 POP PUSH2 0x2CDA SWAP3 SWAP1 SWAP2 DUP11 SWAP2 DUP11 SWAP2 DUP3 SWAP2 DUP6 ADD SWAP1 DUP5 SWAP1 DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST DUP8 PUSH2 0x1D6F DUP3 DUP10 DUP10 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x2D0D JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP10 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x0 DUP1 DUP3 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2E19 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x2E46 PUSH32 0x0 DUP13 DUP13 PUSH2 0x4135 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x23B872DD00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP4 AND PUSH1 0x24 DUP3 ADD DUP2 SWAP1 MSTORE PUSH1 0x44 DUP3 ADD DUP14 SWAP1 MSTORE SWAP2 MLOAD SWAP3 SWAP4 POP SWAP1 SWAP2 PUSH4 0x23B872DD SWAP2 PUSH1 0x64 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2EC7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2EDB JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2EF1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP POP PUSH1 0x40 DUP1 MLOAD PUSH32 0x89AFCB4400000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP9 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP3 MLOAD PUSH1 0x0 SWAP4 DUP5 SWAP4 SWAP3 DUP7 AND SWAP3 PUSH4 0x89AFCB44 SWAP3 PUSH1 0x24 DUP1 DUP4 ADD SWAP4 SWAP3 DUP3 SWAP1 SUB ADD DUP2 DUP8 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2F64 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2F78 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x40 DUP2 LT ISZERO PUSH2 0x2F8E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD SWAP1 SWAP3 POP SWAP1 POP PUSH1 0x0 PUSH2 0x2FA8 DUP15 DUP15 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP15 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2FE5 JUMPI DUP2 DUP4 PUSH2 0x2FE8 JUMP JUMPDEST DUP3 DUP3 JUMPDEST SWAP1 SWAP8 POP SWAP6 POP DUP11 DUP8 LT ISZERO PUSH2 0x3046 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57C1 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP10 DUP7 LT ISZERO PUSH2 0x309F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5727 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP SWAP8 POP SWAP8 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH32 0x0 DUP2 JUMP JUMPDEST PUSH1 0x0 SLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 JUMP JUMPDEST PUSH1 0x60 PUSH2 0x13C2 PUSH32 0x0 DUP5 DUP5 PUSH2 0x1144 PUSH2 0x3FAE JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x3170 PUSH32 0x0 DUP15 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP8 PUSH2 0x317F JUMPI DUP13 PUSH2 0x31A1 JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP13 SWAP1 MSTORE PUSH1 0xFF DUP11 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP10 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP9 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x323D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3251 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x3263 DUP15 DUP15 DUP15 DUP15 DUP15 DUP15 PUSH2 0xE04 JUMP JUMPDEST SWAP1 SWAP16 SWAP1 SWAP15 POP SWAP13 POP POP POP POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 DUP4 TIMESTAMP DUP2 LT ISZERO PUSH2 0x32ED JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x32FB DUP13 DUP13 DUP13 DUP13 DUP13 DUP13 PUSH2 0x4F62 JUMP JUMPDEST SWAP1 SWAP5 POP SWAP3 POP PUSH1 0x0 PUSH2 0x332D PUSH32 0x0 DUP15 DUP15 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x333B DUP14 CALLER DUP4 DUP9 PUSH2 0x4220 JUMP JUMPDEST PUSH2 0x3347 DUP13 CALLER DUP4 DUP8 PUSH2 0x4220 JUMP JUMPDEST DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x6A627842 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x33C6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x33DA JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x33F0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP5 SWAP14 SWAP4 SWAP13 POP SWAP4 SWAP11 POP SWAP2 SWAP9 POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 DUP4 TIMESTAMP DUP2 LT ISZERO PUSH2 0x347C JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x34AA DUP11 PUSH32 0x0 DUP12 CALLVALUE DUP13 DUP13 PUSH2 0x4F62 JUMP JUMPDEST SWAP1 SWAP5 POP SWAP3 POP PUSH1 0x0 PUSH2 0x34FC PUSH32 0x0 DUP13 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x350A DUP12 CALLER DUP4 DUP9 PUSH2 0x4220 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP6 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3572 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3586 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB DUP3 DUP7 PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3632 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3646 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x365C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3664 JUMPI INVALID JUMPDEST DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x6A627842 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x36E3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x36F7 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x370D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP3 POP CALLVALUE DUP5 LT ISZERO PUSH2 0x3725 JUMPI PUSH2 0x3725 CALLER DUP6 CALLVALUE SUB PUSH2 0x3D4D JUMP JUMPDEST POP POP SWAP7 POP SWAP7 POP SWAP7 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x37A5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x37E9 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x3888 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x38EA PUSH32 0x0 DUP9 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP CALLVALUE DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x38FA JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x3959 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x39A2 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x39D5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x39E9 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x3A5B PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP5 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3A68 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3AD9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3AED JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x3B03 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3B0B JUMPI INVALID JUMPDEST PUSH2 0x3B4A DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST DUP2 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3B57 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD CALLVALUE GT ISZERO PUSH2 0x2558 JUMPI PUSH2 0x2558 CALLER DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3B77 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD CALLVALUE SUB PUSH2 0x3D4D JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE PUSH1 0x44 DUP1 DUP4 ADD DUP6 SWAP1 MSTORE DUP4 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0x64 SWAP1 SWAP3 ADD DUP4 MSTORE PUSH1 0x20 DUP3 ADD DUP1 MLOAD PUSH28 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH32 0xA9059CBB00000000000000000000000000000000000000000000000000000000 OR DUP2 MSTORE SWAP3 MLOAD DUP3 MLOAD PUSH1 0x0 SWAP5 PUSH1 0x60 SWAP5 SWAP4 DUP10 AND SWAP4 SWAP3 SWAP2 DUP3 SWAP2 SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x3C5C JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x3C1F JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP7 GAS CALL SWAP2 POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x3CBE JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x3CC3 JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP SWAP2 POP SWAP2 POP DUP2 DUP1 ISZERO PUSH2 0x3CF1 JUMPI POP DUP1 MLOAD ISZERO DUP1 PUSH2 0x3CF1 JUMPI POP DUP1 DUP1 PUSH1 0x20 ADD SWAP1 MLOAD PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x3CEE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD JUMPDEST PUSH2 0x3D46 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2D DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5812 PUSH1 0x2D SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x0 DUP1 DUP3 MSTORE PUSH1 0x20 DUP3 ADD SWAP1 SWAP3 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP1 DUP4 SWAP1 PUSH1 0x40 MLOAD DUP1 DUP3 DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x3DC4 JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x3D87 JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP8 GAS CALL SWAP3 POP POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x3E26 JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x3E2B JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP POP SWAP1 POP DUP1 PUSH2 0x3E85 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x34 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x56CE PUSH1 0x34 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x3EE4 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x583F PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x3EF4 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x3F49 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x3F5D DUP6 PUSH2 0x3E5 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F71 DUP3 DUP6 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F97 DUP4 PUSH2 0x3F8B DUP9 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x52E9 AND JUMP JUMPDEST SWAP1 POP DUP1 DUP3 DUP2 PUSH2 0x3FA2 JUMPI INVALID JUMPDEST DIV SWAP8 SWAP7 POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 SLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER EQ ISZERO SWAP1 JUMP JUMPDEST PUSH1 0x60 PUSH1 0x2 DUP4 MLOAD LT ISZERO PUSH2 0x4040 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A20494E56414C49445F504154480000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP3 MLOAD PUSH8 0xFFFFFFFFFFFFFFFF DUP2 GT DUP1 ISZERO PUSH2 0x4058 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x4082 JUMPI DUP2 PUSH1 0x20 ADD PUSH1 0x20 DUP3 MUL DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP SWAP1 POP DUP4 DUP2 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x4093 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD DUP2 DUP2 MSTORE POP POP PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP5 MLOAD SUB DUP2 LT ISZERO PUSH2 0x412C JUMPI PUSH1 0x0 DUP1 PUSH2 0x40E5 DUP9 DUP8 DUP6 DUP2 MLOAD DUP2 LT PUSH2 0x40C1 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP9 DUP7 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x40D8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x535B JUMP JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x4108 DUP5 DUP5 DUP2 MLOAD DUP2 LT PUSH2 0x40F8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP4 DUP4 DUP9 PUSH2 0x5443 JUMP JUMPDEST DUP5 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4117 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE POP POP PUSH1 0x1 ADD PUSH2 0x40A2 JUMP JUMPDEST POP SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x4144 DUP6 DUP6 PUSH2 0x4E0F JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000 PUSH1 0x60 SWAP5 DUP6 SHL DUP2 AND PUSH1 0x20 DUP1 DUP5 ADD SWAP2 SWAP1 SWAP2 MSTORE SWAP4 DUP6 SHL DUP2 AND PUSH1 0x34 DUP4 ADD MSTORE DUP3 MLOAD PUSH1 0x28 DUP2 DUP5 SUB ADD DUP2 MSTORE PUSH1 0x48 DUP4 ADD DUP5 MSTORE DUP1 MLOAD SWAP1 DUP6 ADD KECCAK256 PUSH32 0xFF00000000000000000000000000000000000000000000000000000000000000 PUSH1 0x68 DUP5 ADD MSTORE SWAP11 SWAP1 SWAP5 SHL SWAP1 SWAP4 AND PUSH1 0x69 DUP5 ADD MSTORE PUSH1 0x7D DUP4 ADD SWAP9 SWAP1 SWAP9 MSTORE PUSH32 0x96E8AC4277198FF8B6F785478AA9A39F403CB768DD02CBEE326C3E7DA348845F PUSH1 0x9D DUP1 DUP5 ADD SWAP2 SWAP1 SWAP2 MSTORE DUP9 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0xBD SWAP1 SWAP3 ADD SWAP1 SWAP8 MSTORE DUP1 MLOAD SWAP7 ADD SWAP6 SWAP1 SWAP6 KECCAK256 SWAP6 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP6 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE DUP5 DUP2 AND PUSH1 0x44 DUP4 ADD MSTORE PUSH1 0x64 DUP1 DUP4 ADD DUP6 SWAP1 MSTORE DUP4 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0x84 SWAP1 SWAP3 ADD DUP4 MSTORE PUSH1 0x20 DUP3 ADD DUP1 MLOAD PUSH28 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH32 0x23B872DD00000000000000000000000000000000000000000000000000000000 OR DUP2 MSTORE SWAP3 MLOAD DUP3 MLOAD PUSH1 0x0 SWAP5 PUSH1 0x60 SWAP5 SWAP4 DUP11 AND SWAP4 SWAP3 SWAP2 DUP3 SWAP2 SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x42FE JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x42C1 JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP7 GAS CALL SWAP2 POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x4360 JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x4365 JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP SWAP2 POP SWAP2 POP DUP2 DUP1 ISZERO PUSH2 0x4393 JUMPI POP DUP1 MLOAD ISZERO DUP1 PUSH2 0x4393 JUMPI POP DUP1 DUP1 PUSH1 0x20 ADD SWAP1 MLOAD PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x4390 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD JUMPDEST PUSH2 0x43E8 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x31 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x569D PUSH1 0x31 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP4 MLOAD SUB DUP2 LT ISZERO PUSH2 0x4671 JUMPI PUSH1 0x0 DUP1 DUP5 DUP4 DUP2 MLOAD DUP2 LT PUSH2 0x440E JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP6 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4425 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH2 0x443D DUP4 DUP4 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 DUP8 DUP6 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4451 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP1 POP PUSH1 0x0 DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x4499 JUMPI DUP3 PUSH1 0x0 PUSH2 0x449D JUMP JUMPDEST PUSH1 0x0 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH1 0x2 DUP11 MLOAD SUB DUP9 LT PUSH2 0x44B4 JUMPI DUP9 PUSH2 0x44F5 JUMP JUMPDEST PUSH2 0x44F5 PUSH32 0x0 DUP8 DUP13 DUP12 PUSH1 0x2 ADD DUP2 MLOAD DUP2 LT PUSH2 0x44E8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x4522 PUSH32 0x0 DUP9 DUP9 PUSH2 0x4135 JUMP JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x22C0D9F DUP5 DUP5 DUP5 PUSH1 0x0 PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x1F ADD PUSH1 0x1F NOT AND PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x456C JUMPI PUSH1 0x20 DUP3 ADD DUP2 DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP PUSH1 0x40 MLOAD DUP6 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP6 DUP2 MSTORE PUSH1 0x20 ADD DUP5 DUP2 MSTORE PUSH1 0x20 ADD DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE DUP4 DUP2 DUP2 MLOAD DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x45F7 JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x45DF JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0x4624 JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP SWAP6 POP POP POP POP POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x4646 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x465A JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP PUSH1 0x1 SWAP1 SWAP10 ADD SWAP9 POP PUSH2 0x43F3 SWAP8 POP POP POP POP POP POP POP POP JUMP JUMPDEST POP POP POP POP JUMP JUMPDEST PUSH1 0x60 PUSH1 0x2 DUP4 MLOAD LT ISZERO PUSH2 0x46EA JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A20494E56414C49445F504154480000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP3 MLOAD PUSH8 0xFFFFFFFFFFFFFFFF DUP2 GT DUP1 ISZERO PUSH2 0x4702 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x472C JUMPI DUP2 PUSH1 0x20 ADD PUSH1 0x20 DUP3 MUL DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP SWAP1 POP DUP4 DUP2 PUSH1 0x1 DUP4 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x4740 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE DUP3 MLOAD PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF ADD JUMPDEST DUP1 ISZERO PUSH2 0x412C JUMPI PUSH1 0x0 DUP1 PUSH2 0x47A0 DUP9 DUP8 PUSH1 0x1 DUP7 SUB DUP2 MLOAD DUP2 LT PUSH2 0x478C JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP9 DUP7 DUP2 MLOAD DUP2 LT PUSH2 0x40D8 JUMPI INVALID JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x47C3 DUP5 DUP5 DUP2 MLOAD DUP2 LT PUSH2 0x47B3 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP4 DUP4 DUP9 PUSH2 0x5571 JUMP JUMPDEST DUP5 PUSH1 0x1 DUP6 SUB DUP2 MLOAD DUP2 LT PUSH2 0x47D2 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE POP POP PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF ADD PUSH2 0x4770 JUMP JUMPDEST PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP4 MLOAD SUB DUP2 LT ISZERO PUSH2 0x3E85 JUMPI PUSH1 0x0 DUP1 DUP5 DUP4 DUP2 MLOAD DUP2 LT PUSH2 0x4824 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP6 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x483B JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH2 0x4853 DUP4 DUP4 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 PUSH2 0x4883 PUSH32 0x0 DUP6 DUP6 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP1 PUSH1 0x0 DUP1 DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x902F1AC PUSH1 0x40 MLOAD DUP2 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x60 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x48D1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x48E5 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x48FB JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD PUSH14 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP2 DUP3 AND SWAP4 POP AND SWAP1 POP PUSH1 0x0 DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP11 DUP2 AND SWAP1 DUP10 AND EQ PUSH2 0x4945 JUMPI DUP3 DUP5 PUSH2 0x4948 JUMP JUMPDEST DUP4 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x49CD DUP3 DUP12 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP11 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP6 POP PUSH2 0x49DA DUP7 DUP4 DUP4 PUSH2 0x3E8A JUMP JUMPDEST SWAP5 POP POP POP POP POP PUSH1 0x0 DUP1 DUP6 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP9 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x4A1E JUMPI DUP3 PUSH1 0x0 PUSH2 0x4A22 JUMP JUMPDEST PUSH1 0x0 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH1 0x2 DUP13 MLOAD SUB DUP11 LT PUSH2 0x4A39 JUMPI DUP11 PUSH2 0x4A6D JUMP JUMPDEST PUSH2 0x4A6D PUSH32 0x0 DUP10 DUP15 DUP14 PUSH1 0x2 ADD DUP2 MLOAD DUP2 LT PUSH2 0x44E8 JUMPI INVALID JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x0 DUP1 DUP3 MSTORE PUSH1 0x20 DUP3 ADD SWAP3 DUP4 SWAP1 MSTORE PUSH32 0x22C0D9F00000000000000000000000000000000000000000000000000000000 DUP4 MSTORE PUSH1 0x24 DUP3 ADD DUP8 DUP2 MSTORE PUSH1 0x44 DUP4 ADD DUP8 SWAP1 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP1 DUP7 AND PUSH1 0x64 DUP6 ADD MSTORE PUSH1 0x80 PUSH1 0x84 DUP6 ADD SWAP1 DUP2 MSTORE DUP5 MLOAD PUSH1 0xA4 DUP7 ADD DUP2 SWAP1 MSTORE SWAP7 SWAP8 POP SWAP1 DUP13 AND SWAP6 PUSH4 0x22C0D9F SWAP6 DUP11 SWAP6 DUP11 SWAP6 DUP11 SWAP6 SWAP2 SWAP5 SWAP2 SWAP4 SWAP2 SWAP3 PUSH1 0xC4 DUP7 ADD SWAP3 SWAP1 SWAP2 DUP2 SWAP1 DUP5 SWAP1 DUP5 SWAP1 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x4B1D JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x4B05 JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0x4B4A JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP SWAP6 POP POP POP POP POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x4B6C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x4B80 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP PUSH1 0x1 SWAP1 SWAP12 ADD SWAP11 POP PUSH2 0x4809 SWAP10 POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 DUP3 SUB DUP3 DUP2 GT ISZERO PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x15 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D7375622D756E646572666C6F770000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x4C65 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2C DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5671 PUSH1 0x2C SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x4C75 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x4CCA JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x4CEE PUSH2 0x3E8 PUSH2 0x4CE2 DUP7 DUP9 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x4D08 PUSH2 0x3E5 PUSH2 0x4CE2 DUP7 DUP10 PUSH4 0xFFFFFFFF PUSH2 0x4B99 AND JUMP JUMPDEST SWAP1 POP PUSH2 0x4D25 PUSH1 0x1 DUP3 DUP5 DUP2 PUSH2 0x4D18 JUMPI INVALID JUMPDEST DIV SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x52E9 AND JUMP JUMPDEST SWAP7 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x4D89 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x25 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5775 PUSH1 0x25 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x4D99 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x4DEE JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP3 PUSH2 0x4DFF DUP6 DUP5 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST DUP2 PUSH2 0x4E06 JUMPI INVALID JUMPDEST DIV SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ ISZERO PUSH2 0x4E97 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x25 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5702 PUSH1 0x25 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND LT PUSH2 0x4ED1 JUMPI DUP3 DUP5 PUSH2 0x4ED4 JUMP JUMPDEST DUP4 DUP4 JUMPDEST SWAP1 SWAP3 POP SWAP1 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP3 AND PUSH2 0x4F5B JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A205A45524F5F414444524553530000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST SWAP3 POP SWAP3 SWAP1 POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xE6A4390500000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP9 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP8 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE SWAP2 MLOAD PUSH1 0x0 SWAP3 DUP4 SWAP3 DUP4 SWAP3 PUSH32 0x0 SWAP1 SWAP3 AND SWAP2 PUSH4 0xE6A43905 SWAP2 PUSH1 0x44 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x5002 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x5016 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x502C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ ISZERO PUSH2 0x5112 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0xC9C6539600000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP11 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP10 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE SWAP2 MLOAD PUSH32 0x0 SWAP1 SWAP3 AND SWAP2 PUSH4 0xC9C65396 SWAP2 PUSH1 0x44 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x50E5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x50F9 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x510F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP POP JUMPDEST PUSH1 0x0 DUP1 PUSH2 0x5140 PUSH32 0x0 DUP12 DUP12 PUSH2 0x535B JUMP JUMPDEST SWAP2 POP SWAP2 POP DUP2 PUSH1 0x0 EQ DUP1 ISZERO PUSH2 0x5152 JUMPI POP DUP1 ISZERO JUMPDEST ISZERO PUSH2 0x5162 JUMPI DUP8 SWAP4 POP DUP7 SWAP3 POP PUSH2 0x5256 JUMP JUMPDEST PUSH1 0x0 PUSH2 0x516F DUP10 DUP5 DUP5 PUSH2 0x4D2F JUMP JUMPDEST SWAP1 POP DUP8 DUP2 GT PUSH2 0x51DC JUMPI DUP6 DUP2 LT ISZERO PUSH2 0x51D1 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5727 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP9 SWAP5 POP SWAP3 POP DUP3 PUSH2 0x5254 JUMP JUMPDEST PUSH1 0x0 PUSH2 0x51E9 DUP10 DUP5 DUP7 PUSH2 0x4D2F JUMP JUMPDEST SWAP1 POP DUP10 DUP2 GT ISZERO PUSH2 0x51F5 JUMPI INVALID JUMPDEST DUP8 DUP2 LT ISZERO PUSH2 0x524E JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57C1 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST SWAP5 POP DUP8 SWAP4 POP JUMPDEST POP JUMPDEST POP POP SWAP7 POP SWAP7 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO DUP1 PUSH2 0x527E JUMPI POP POP DUP1 DUP3 MUL DUP3 DUP3 DUP3 DUP2 PUSH2 0x527B JUMPI INVALID JUMPDEST DIV EQ JUMPDEST PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x14 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D6D756C2D6F766572666C6F77000000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP1 DUP3 ADD DUP3 DUP2 LT ISZERO PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x14 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D6164642D6F766572666C6F77000000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x536A DUP6 DUP6 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 DUP1 PUSH2 0x537B DUP9 DUP9 DUP9 PUSH2 0x4135 JUMP JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x902F1AC PUSH1 0x40 MLOAD DUP2 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x60 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x53C0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x53D4 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x53EA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD PUSH14 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP2 DUP3 AND SWAP4 POP AND SWAP1 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP8 DUP2 AND SWAP1 DUP5 AND EQ PUSH2 0x5431 JUMPI DUP1 DUP3 PUSH2 0x5434 JUMP JUMPDEST DUP2 DUP2 JUMPDEST SWAP1 SWAP10 SWAP1 SWAP9 POP SWAP7 POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO PUSH2 0x545D JUMPI PUSH2 0x5456 DUP6 DUP6 DUP6 PUSH2 0x3E8A JUMP JUMPDEST SWAP1 POP PUSH2 0xF64 JUMP JUMPDEST PUSH1 0x0 DUP6 GT PUSH2 0x54B6 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x583F PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP5 GT DUP1 ISZERO PUSH2 0x54C6 JUMPI POP PUSH1 0x0 DUP4 GT JUMPDEST PUSH2 0x551B JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x552F DUP7 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x5543 DUP3 DUP7 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x5559 DUP8 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP DUP1 DUP3 DUP2 PUSH2 0x5564 JUMPI INVALID JUMPDEST DIV SWAP9 SWAP8 POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO PUSH2 0x5584 JUMPI PUSH2 0x5456 DUP6 DUP6 DUP6 PUSH2 0x4C0B JUMP JUMPDEST PUSH1 0x0 DUP6 GT PUSH2 0x55DD JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2C DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5671 PUSH1 0x2C SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP5 GT DUP1 ISZERO PUSH2 0x55ED JUMPI POP PUSH1 0x0 DUP4 GT JUMPDEST PUSH2 0x5642 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x565A PUSH2 0x3E8 PUSH2 0x4CE2 DUP8 DUP10 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F97 DUP6 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP INVALID SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4F SSTORE SLOAD POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SLOAD PUSH19 0x616E7366657248656C7065723A3A7472616E73 PUSH7 0x657246726F6D3A KECCAK256 PUSH21 0x72616E7366657246726F6D206661696C6564547261 PUSH15 0x7366657248656C7065723A3A736166 PUSH6 0x5472616E7366 PUSH6 0x724554483A20 GASLIMIT SLOAD 0x48 KECCAK256 PUSH21 0x72616E73666572206661696C6564556E6973776170 JUMP ORIGIN 0x4C PUSH10 0x62726172793A20494445 0x4E SLOAD 0x49 NUMBER COINBASE 0x4C 0x5F COINBASE DIFFICULTY DIFFICULTY MSTORE GASLIMIT MSTORE8 MSTORE8 GASLIMIT MSTORE8 SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F TIMESTAMP 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4C 0x49 MLOAD SSTORE 0x49 DIFFICULTY 0x49 SLOAD MSIZE SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 GASLIMIT PC NUMBER GASLIMIT MSTORE8 MSTORE8 0x49 JUMP GASLIMIT 0x5F 0x49 0x4E POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F COINBASE 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4F SSTORE SLOAD POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SLOAD PUSH19 0x616E7366657248656C7065723A3A7361666554 PUSH19 0x616E736665723A207472616E73666572206661 PUSH10 0x6C6564556E6973776170 JUMP ORIGIN 0x4C PUSH10 0x62726172793A20494E53 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x49 0x4E POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD LOG2 PUSH5 0x6970667358 0x22 SLT KECCAK256 PUSH19 0x7DDC3491766F9B8DC46E1C4BAFBFDB094815AD 0xE2 0xAF JUMPI LOG4 PUSH17 0x3D38A9B8E4709C64736F6C634300060600 CALLER ",
+      "sourceMap": "350:18983:10:-:0;;;691:176;5:9:-1;2:2;;;27:1;24;17:12;2:2;691:176:10;;;;;;;;;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;691:176:10;;;;;;;;;;;;778:18;;;-1:-1:-1;;;;;;778:18:10;;;;;806:12;;;;;;;828:14;:32;;-1:-1:-1;;;;;;828:32:10;-1:-1:-1;;;;;828:32:10;;;;;;350:18983;;;;;;;;;;;;;;;"
+    },
+    "deployedBytecode": {
+      "immutableReferences": {
+        "3491": [
+          {
+            "length": 32,
+            "start": 4327
+          },
+          {
+            "length": 32,
+            "start": 4590
+          },
+          {
+            "length": 32,
+            "start": 5012
+          },
+          {
+            "length": 32,
+            "start": 5077
+          },
+          {
+            "length": 32,
+            "start": 5504
+          },
+          {
+            "length": 32,
+            "start": 6169
+          },
+          {
+            "length": 32,
+            "start": 6381
+          },
+          {
+            "length": 32,
+            "start": 6874
+          },
+          {
+            "length": 32,
+            "start": 8856
+          },
+          {
+            "length": 32,
+            "start": 9277
+          },
+          {
+            "length": 32,
+            "start": 9702
+          },
+          {
+            "length": 32,
+            "start": 10973
+          },
+          {
+            "length": 32,
+            "start": 11808
+          },
+          {
+            "length": 32,
+            "start": 12466
+          },
+          {
+            "length": 32,
+            "start": 12535
+          },
+          {
+            "length": 32,
+            "start": 12586
+          },
+          {
+            "length": 32,
+            "start": 13063
+          },
+          {
+            "length": 32,
+            "start": 13494
+          },
+          {
+            "length": 32,
+            "start": 14477
+          },
+          {
+            "length": 32,
+            "start": 14895
+          },
+          {
+            "length": 32,
+            "start": 17593
+          },
+          {
+            "length": 32,
+            "start": 17660
+          },
+          {
+            "length": 32,
+            "start": 18525
+          },
+          {
+            "length": 32,
+            "start": 19006
+          },
+          {
+            "length": 32,
+            "start": 20409
+          },
+          {
+            "length": 32,
+            "start": 20634
+          },
+          {
+            "length": 32,
+            "start": 20762
+          }
+        ],
+        "3494": [
+          {
+            "length": 32,
+            "start": 439
+          },
+          {
+            "length": 32,
+            "start": 3709
+          },
+          {
+            "length": 32,
+            "start": 3768
+          },
+          {
+            "length": 32,
+            "start": 4085
+          },
+          {
+            "length": 32,
+            "start": 4801
+          },
+          {
+            "length": 32,
+            "start": 5927
+          },
+          {
+            "length": 32,
+            "start": 6415
+          },
+          {
+            "length": 32,
+            "start": 7767
+          },
+          {
+            "length": 32,
+            "start": 8155
+          },
+          {
+            "length": 32,
+            "start": 8363
+          },
+          {
+            "length": 32,
+            "start": 8626
+          },
+          {
+            "length": 32,
+            "start": 9065
+          },
+          {
+            "length": 32,
+            "start": 9214
+          },
+          {
+            "length": 32,
+            "start": 9908
+          },
+          {
+            "length": 32,
+            "start": 10075
+          },
+          {
+            "length": 32,
+            "start": 10288
+          },
+          {
+            "length": 32,
+            "start": 10549
+          },
+          {
+            "length": 32,
+            "start": 10781
+          },
+          {
+            "length": 32,
+            "start": 10910
+          },
+          {
+            "length": 32,
+            "start": 12620
+          },
+          {
+            "length": 32,
+            "start": 13442
+          },
+          {
+            "length": 32,
+            "start": 13528
+          },
+          {
+            "length": 32,
+            "start": 13580
+          },
+          {
+            "length": 32,
+            "start": 13709
+          },
+          {
+            "length": 32,
+            "start": 14247
+          },
+          {
+            "length": 32,
+            "start": 14683
+          },
+          {
+            "length": 32,
+            "start": 14832
+          }
+        ]
+      },
+      "linkReferences": {},
+      "object": "60806040526004361061019a5760003560e01c80638803dbee116100e1578063c45a01551161008a578063ded9382a11610064578063ded9382a14610c11578063e8e3370014610c91578063f305d71914610d1e578063fb3bdb4114610d71576101e0565b8063c45a015514610b30578063caa0c28c14610b45578063d06ca61f14610b5a576101e0565b8063af2979eb116100bb578063af2979eb146109d3578063b6f9de9514610a33578063baa2abde14610ac6576101e0565b80638803dbee146108ba578063ad5c46481461095f578063ad615dec1461099d576101e0565b80634a25d94a11610143578063791ac9471161011d578063791ac9471461074c5780637ff36ab5146107f157806385f8c25914610884576101e0565b80634a25d94a146105825780635b0d5984146106275780635c11d795146106a7576101e0565b80631f00ca74116101745780631f00ca741461039b5780632195995c1461045257806338ed1739146104dd576101e0565b806302751cec146101e5578063054d50d41461025e57806318cbafe5146102a6576101e0565b366101e0573373ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016146101de57fe5b005b600080fd5b3480156101f157600080fd5b50610245600480360360c081101561020857600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135610e04565b6040805192835260208301919091528051918290030190f35b34801561026a57600080fd5b506102946004803603606081101561028157600080fd5b5080359060208101359060400135610f57565b60408051918252519081900360200190f35b3480156102b257600080fd5b5061034b600480360360a08110156102c957600080fd5b8135916020810135918101906060810160408201356401000000008111156102f057600080fd5b82018360208201111561030257600080fd5b8035906020019184602083028401116401000000008311171561032457600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135610f6c565b60408051602080825283518183015283519192839290830191858101910280838360005b8381101561038757818101518382015260200161036f565b505050509050019250505060405180910390f35b3480156103a757600080fd5b5061034b600480360360408110156103be57600080fd5b813591908101906040810160208201356401000000008111156103e057600080fd5b8201836020820111156103f257600080fd5b8035906020019184602083028401116401000000008311171561041457600080fd5b91908080602002602001604051908101604052809392919081815260200183836020028082843760009201919091525092955061138d945050505050565b34801561045e57600080fd5b50610245600480360361016081101561047657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c08101359060e081013515159060ff61010082013516906101208101359061014001356113cb565b3480156104e957600080fd5b5061034b600480360360a081101561050057600080fd5b81359160208101359181019060608101604082013564010000000081111561052757600080fd5b82018360208201111561053957600080fd5b8035906020019184602083028401116401000000008311171561055b57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611509565b34801561058e57600080fd5b5061034b600480360360a08110156105a557600080fd5b8135916020810135918101906060810160408201356401000000008111156105cc57600080fd5b8201836020820111156105de57600080fd5b8035906020019184602083028401116401000000008311171561060057600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561169e565b34801561063357600080fd5b50610294600480360361014081101561064b57600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e082013516906101008101359061012001356118e5565b3480156106b357600080fd5b506101de600480360360a08110156106ca57600080fd5b8135916020810135918101906060810160408201356401000000008111156106f157600080fd5b82018360208201111561070357600080fd5b8035906020019184602083028401116401000000008311171561072557600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611a37565b34801561075857600080fd5b506101de600480360360a081101561076f57600080fd5b81359160208101359181019060608101604082013564010000000081111561079657600080fd5b8201836020820111156107a857600080fd5b803590602001918460208302840111640100000000831117156107ca57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611dd0565b61034b6004803603608081101561080757600080fd5b8135919081019060408101602082013564010000000081111561082957600080fd5b82018360208201111561083b57600080fd5b8035906020019184602083028401116401000000008311171561085d57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561213e565b34801561089057600080fd5b50610294600480360360608110156108a757600080fd5b5080359060208101359060400135612562565b3480156108c657600080fd5b5061034b600480360360a08110156108dd57600080fd5b81359160208101359181019060608101604082013564010000000081111561090457600080fd5b82018360208201111561091657600080fd5b8035906020019184602083028401116401000000008311171561093857600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561256f565b34801561096b57600080fd5b506109746126b2565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b3480156109a957600080fd5b50610294600480360360608110156109c057600080fd5b50803590602081013590604001356126d6565b3480156109df57600080fd5b50610294600480360360c08110156109f657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a001356126e3565b6101de60048036036080811015610a4957600080fd5b81359190810190604081016020820135640100000000811115610a6b57600080fd5b820183602082011115610a7d57600080fd5b80359060200191846020830284011164010000000083111715610a9f57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff81351690602001356128c3565b348015610ad257600080fd5b50610245600480360360e0811015610ae957600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c00135612da6565b348015610b3c57600080fd5b506109746130b0565b348015610b5157600080fd5b506109746130d4565b348015610b6657600080fd5b5061034b60048036036040811015610b7d57600080fd5b81359190810190604081016020820135640100000000811115610b9f57600080fd5b820183602082011115610bb157600080fd5b80359060200191846020830284011164010000000083111715610bd357600080fd5b9190808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152509295506130f0945050505050565b348015610c1d57600080fd5b506102456004803603610140811015610c3557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e08201351690610100810135906101200135613120565b348015610c9d57600080fd5b50610d006004803603610100811015610cb557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359160c0820135169060e00135613278565b60408051938452602084019290925282820152519081900360600190f35b610d00600480360360c0811015610d3457600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135613407565b61034b60048036036080811015610d8757600080fd5b81359190810190604081016020820135640100000000811115610da957600080fd5b820183602082011115610dbb57600080fd5b80359060200191846020830284011164010000000083111715610ddd57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135613733565b6000808242811015610e7757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b610ea6897f00000000000000000000000000000000000000000000000000000000000000008a8a8a308a612da6565b9093509150610eb6898685613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b158015610f2957600080fd5b505af1158015610f3d573d6000803e3d6000fd5b50505050610f4b8583613d4d565b50965096945050505050565b6000610f64848484613e8a565b949350505050565b60608142811015610fde57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061104357fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16146110e257604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6111497f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b613fcd565b9150868260018451038151811061115c57fe5b602002602001015110156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b611280868660008181106111cb57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16336112667f00000000000000000000000000000000000000000000000000000000000000008a8a600081811061121a57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168b8b600181811061124457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16614135565b8560008151811061127357fe5b6020026020010151614220565b6112bf828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152503092506143f0915050565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d8360018551038151811061130b57fe5b60200260200101516040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561134957600080fd5b505af115801561135d573d6000803e3d6000fd5b50505050611382848360018551038151811061137557fe5b6020026020010151613d4d565b509695505050505050565b60606113c27f000000000000000000000000000000000000000000000000000000000000000084846113bd613fae565b614677565b90505b92915050565b60008060006113fb7f00000000000000000000000000000000000000000000000000000000000000008f8f614135565b905060008761140a578c61142c565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b1580156114c857600080fd5b505af11580156114dc573d6000803e3d6000fd5b505050506114ef8f8f8f8f8f8f8f612da6565b809450819550505050509b509b9950505050505050505050565b6060814281101561157b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6115dd7f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b915086826001845103815181106115f057fe5b6020026020010151101561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b61165f868660008181106111cb57fe5b611382828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b6060814281101561171057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061177557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461181457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6118767f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061188657fe5b602002602001015111156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b6000806119337f00000000000000000000000000000000000000000000000000000000000000008d7f0000000000000000000000000000000000000000000000000000000000000000614135565b9050600086611942578b611964565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018b905260ff8916608482015260a4810188905260c48101879052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b158015611a0057600080fd5b505af1158015611a14573d6000803e3d6000fd5b50505050611a268d8d8d8d8d8d6126e3565b9d9c50505050505050505050505050565b8042811015611aa757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b611b3685856000818110611ab757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1633611b307f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168a8a600181811061124457fe5b8a614220565b600085857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611b6657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231856040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611bff57600080fd5b505afa158015611c13573d6000803e3d6000fd5b505050506040513d6020811015611c2957600080fd5b50516040805160208881028281018201909352888252929350611c6b929091899189918291850190849080828437600092019190915250889250614806915050565b86611d6f8288887fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611c9e57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b505afa158015611d4b573d6000803e3d6000fd5b505050506040513d6020811015611d6157600080fd5b50519063ffffffff614b9916565b1015611dc6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b5050505050505050565b8042811015611e4057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001685857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611ea557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614611f4457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b611f5485856000818110611ab757fe5b611f92858580806020026020016040519081016040528093929190818152602001838360200280828437600092019190915250309250614806915050565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905160009173ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016916370a0823191602480820192602092909190829003018186803b15801561202257600080fd5b505afa158015612036573d6000803e3d6000fd5b505050506040513d602081101561204c57600080fd5b50519050868110156120a9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d826040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561211c57600080fd5b505af1158015612130573d6000803e3d6000fd5b50505050611dc68482613d4d565b606081428110156121b057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106121f457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461229357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6122f57f0000000000000000000000000000000000000000000000000000000000000000348888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b9150868260018451038151811061230857fe5b60200260200101511015612367576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106123b057fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156123e357600080fd5b505af11580156123f7573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb6124697f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b8460008151811061247657fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b1580156124e757600080fd5b505af11580156124fb573d6000803e3d6000fd5b505050506040513d602081101561251157600080fd5b505161251957fe5b612558828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b5095945050505050565b6000610f64848484614c0b565b606081428110156125e157604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6126437f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061265357fe5b6020026020010151111561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000081565b6000610f64848484614d2f565b6000814281101561275557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b612784887f00000000000000000000000000000000000000000000000000000000000000008989893089612da6565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905191945061282e92508a91879173ffffffffffffffffffffffffffffffffffffffff8416916370a0823191602480820192602092909190829003018186803b1580156127fd57600080fd5b505afa158015612811573d6000803e3d6000fd5b505050506040513d602081101561282757600080fd5b5051613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b1580156128a157600080fd5b505af11580156128b5573d6000803e3d6000fd5b505050506113828483613d4d565b804281101561293357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff168585600081811061297757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614612a1657604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b60003490507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0826040518263ffffffff1660e01b81526004016000604051808303818588803b158015612a8357600080fd5b505af1158015612a97573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb612b097f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b836040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015612b7357600080fd5b505af1158015612b87573d6000803e3d6000fd5b505050506040513d6020811015612b9d57600080fd5b5051612ba557fe5b600086867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612bd557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231866040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015612c6e57600080fd5b505afa158015612c82573d6000803e3d6000fd5b505050506040513d6020811015612c9857600080fd5b50516040805160208981028281018201909352898252929350612cda9290918a918a918291850190849080828437600092019190915250899250614806915050565b87611d6f8289897fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612d0d57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231896040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b6000808242811015612e1957604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6000612e467f00000000000000000000000000000000000000000000000000000000000000008c8c614135565b604080517f23b872dd00000000000000000000000000000000000000000000000000000000815233600482015273ffffffffffffffffffffffffffffffffffffffff831660248201819052604482018d9052915192935090916323b872dd916064808201926020929091908290030181600087803b158015612ec757600080fd5b505af1158015612edb573d6000803e3d6000fd5b505050506040513d6020811015612ef157600080fd5b5050604080517f89afcb4400000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015282516000938493928616926389afcb44926024808301939282900301818787803b158015612f6457600080fd5b505af1158015612f78573d6000803e3d6000fd5b505050506040513d6040811015612f8e57600080fd5b50805160209091015190925090506000612fa88e8e614e0f565b5090508073ffffffffffffffffffffffffffffffffffffffff168e73ffffffffffffffffffffffffffffffffffffffff1614612fe5578183612fe8565b82825b90975095508a871015613046576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b8986101561309f576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b505050505097509795505050505050565b7f000000000000000000000000000000000000000000000000000000000000000081565b60005473ffffffffffffffffffffffffffffffffffffffff1681565b60606113c27f00000000000000000000000000000000000000000000000000000000000000008484611144613fae565b60008060006131707f00000000000000000000000000000000000000000000000000000000000000008e7f0000000000000000000000000000000000000000000000000000000000000000614135565b905060008761317f578c6131a1565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b15801561323d57600080fd5b505af1158015613251573d6000803e3d6000fd5b505050506132638e8e8e8e8e8e610e04565b909f909e509c50505050505050505050505050565b600080600083428110156132ed57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6132fb8c8c8c8c8c8c614f62565b9094509250600061332d7f00000000000000000000000000000000000000000000000000000000000000008e8e614135565b905061333b8d338388614220565b6133478c338387614220565b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156133c657600080fd5b505af11580156133da573d6000803e3d6000fd5b505050506040513d60208110156133f057600080fd5b5051949d939c50939a509198505050505050505050565b6000806000834281101561347c57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6134aa8a7f00000000000000000000000000000000000000000000000000000000000000008b348c8c614f62565b909450925060006134fc7f00000000000000000000000000000000000000000000000000000000000000008c7f0000000000000000000000000000000000000000000000000000000000000000614135565b905061350a8b338388614220565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0856040518263ffffffff1660e01b81526004016000604051808303818588803b15801561357257600080fd5b505af1158015613586573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb82866040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b15801561363257600080fd5b505af1158015613646573d6000803e3d6000fd5b505050506040513d602081101561365c57600080fd5b505161366457fe5b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156136e357600080fd5b505af11580156136f7573d6000803e3d6000fd5b505050506040513d602081101561370d57600080fd5b50519250348410156137255761372533853403613d4d565b505096509650969350505050565b606081428110156137a557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106137e957fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461388857604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6138ea7f0000000000000000000000000000000000000000000000000000000000000000888888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b915034826000815181106138fa57fe5b60200260200101511115613959576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106139a257fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156139d557600080fd5b505af11580156139e9573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb613a5b7f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b84600081518110613a6857fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015613ad957600080fd5b505af1158015613aed573d6000803e3d6000fd5b505050506040513d6020811015613b0357600080fd5b5051613b0b57fe5b613b4a828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b81600081518110613b5757fe5b6020026020010151341115612558576125583383600081518110613b7757fe5b60200260200101513403613d4d565b6040805173ffffffffffffffffffffffffffffffffffffffff8481166024830152604480830185905283518084039091018152606490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167fa9059cbb00000000000000000000000000000000000000000000000000000000178152925182516000946060949389169392918291908083835b60208310613c5c57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613c1f565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114613cbe576040519150601f19603f3d011682016040523d82523d6000602084013e613cc3565b606091505b5091509150818015613cf1575080511580613cf15750808060200190516020811015613cee57600080fd5b50515b613d46576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602d815260200180615812602d913960400191505060405180910390fd5b5050505050565b6040805160008082526020820190925273ffffffffffffffffffffffffffffffffffffffff84169083906040518082805190602001908083835b60208310613dc457805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613d87565b6001836020036101000a03801982511681845116808217855250505050505090500191505060006040518083038185875af1925050503d8060008114613e26576040519150601f19603f3d011682016040523d82523d6000602084013e613e2b565b606091505b5050905080613e85576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260348152602001806156ce6034913960400191505060405180910390fd5b505050565b6000808411613ee4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b600083118015613ef45750600082115b613f49576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000613f5d856103e563ffffffff61526316565b90506000613f71828563ffffffff61526316565b90506000613f9783613f8b886103e863ffffffff61526316565b9063ffffffff6152e916565b9050808281613fa257fe5b04979650505050505050565b60005473ffffffffffffffffffffffffffffffffffffffff1633141590565b606060028351101561404057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561405857600080fd5b50604051908082528060200260200182016040528015614082578160200160208202803683370190505b509050838160008151811061409357fe5b60200260200101818152505060005b600184510381101561412c576000806140e5888785815181106140c157fe5b60200260200101518886600101815181106140d857fe5b602002602001015161535b565b915091506141088484815181106140f857fe5b6020026020010151838388615443565b84846001018151811061411757fe5b602090810291909101015250506001016140a2565b50949350505050565b60008060006141448585614e0f565b604080517fffffffffffffffffffffffffffffffffffffffff000000000000000000000000606094851b811660208084019190915293851b81166034830152825160288184030181526048830184528051908501207fff0000000000000000000000000000000000000000000000000000000000000060688401529a90941b9093166069840152607d8301989098527f96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f609d808401919091528851808403909101815260bd909201909752805196019590952095945050505050565b6040805173ffffffffffffffffffffffffffffffffffffffff85811660248301528481166044830152606480830185905283518084039091018152608490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167f23b872dd0000000000000000000000000000000000000000000000000000000017815292518251600094606094938a169392918291908083835b602083106142fe57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe090920191602091820191016142c1565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114614360576040519150601f19603f3d011682016040523d82523d6000602084013e614365565b606091505b5091509150818015614393575080511580614393575080806020019051602081101561439057600080fd5b50515b6143e8576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252603181526020018061569d6031913960400191505060405180910390fd5b505050505050565b60005b60018351038110156146715760008084838151811061440e57fe5b602002602001015185846001018151811061442557fe5b602002602001015191509150600061443d8383614e0f565b509050600087856001018151811061445157fe5b602002602001015190506000808373ffffffffffffffffffffffffffffffffffffffff168673ffffffffffffffffffffffffffffffffffffffff16146144995782600061449d565b6000835b91509150600060028a510388106144b457886144f5565b6144f57f0000000000000000000000000000000000000000000000000000000000000000878c8b600201815181106144e857fe5b6020026020010151614135565b90506145227f00000000000000000000000000000000000000000000000000000000000000008888614135565b73ffffffffffffffffffffffffffffffffffffffff1663022c0d9f84848460006040519080825280601f01601f19166020018201604052801561456c576020820181803683370190505b506040518563ffffffff1660e01b8152600401808581526020018481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200180602001828103825283818151815260200191508051906020019080838360005b838110156145f75781810151838201526020016145df565b50505050905090810190601f1680156146245780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b15801561464657600080fd5b505af115801561465a573d6000803e3d6000fd5b5050600190990198506143f3975050505050505050565b50505050565b60606002835110156146ea57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561470257600080fd5b5060405190808252806020026020018201604052801561472c578160200160208202803683370190505b509050838160018351038151811061474057fe5b602090810291909101015282517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff015b801561412c576000806147a08887600186038151811061478c57fe5b60200260200101518886815181106140d857fe5b915091506147c38484815181106147b357fe5b6020026020010151838388615571565b8460018503815181106147d257fe5b602090810291909101015250507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01614770565b60005b6001835103811015613e855760008084838151811061482457fe5b602002602001015185846001018151811061483b57fe5b60200260200101519150915060006148538383614e0f565b50905060006148837f00000000000000000000000000000000000000000000000000000000000000008585614135565b90506000806000808473ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156148d157600080fd5b505afa1580156148e5573d6000803e3d6000fd5b505050506040513d60608110156148fb57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905060008073ffffffffffffffffffffffffffffffffffffffff8a811690891614614945578284614948565b83835b915091506149cd828b73ffffffffffffffffffffffffffffffffffffffff166370a082318a6040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b95506149da868383613e8a565b9450505050506000808573ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614614a1e57826000614a22565b6000835b91509150600060028c51038a10614a39578a614a6d565b614a6d7f0000000000000000000000000000000000000000000000000000000000000000898e8d600201815181106144e857fe5b60408051600080825260208201928390527f022c0d9f000000000000000000000000000000000000000000000000000000008352602482018781526044830187905273ffffffffffffffffffffffffffffffffffffffff8086166064850152608060848501908152845160a48601819052969750908c169563022c0d9f958a958a958a9591949193919260c486019290918190849084905b83811015614b1d578181015183820152602001614b05565b50505050905090810190601f168015614b4a5780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b158015614b6c57600080fd5b505af1158015614b80573d6000803e3d6000fd5b50506001909b019a506148099950505050505050505050565b808203828111156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601560248201527f64732d6d6174682d7375622d756e646572666c6f770000000000000000000000604482015290519081900360640190fd5b6000808411614c65576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b600083118015614c755750600082115b614cca576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000614cee6103e8614ce2868863ffffffff61526316565b9063ffffffff61526316565b90506000614d086103e5614ce2868963ffffffff614b9916565b9050614d256001828481614d1857fe5b049063ffffffff6152e916565b9695505050505050565b6000808411614d89576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157756025913960400191505060405180910390fd5b600083118015614d995750600082115b614dee576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b82614dff858463ffffffff61526316565b81614e0657fe5b04949350505050565b6000808273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff161415614e97576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157026025913960400191505060405180910390fd5b8273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff1610614ed1578284614ed4565b83835b909250905073ffffffffffffffffffffffffffffffffffffffff8216614f5b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a205a45524f5f414444524553530000604482015290519081900360640190fd5b9250929050565b604080517fe6a4390500000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015287811660248301529151600092839283927f00000000000000000000000000000000000000000000000000000000000000009092169163e6a4390591604480820192602092909190829003018186803b15801561500257600080fd5b505afa158015615016573d6000803e3d6000fd5b505050506040513d602081101561502c57600080fd5b505173ffffffffffffffffffffffffffffffffffffffff16141561511257604080517fc9c6539600000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff8a81166004830152898116602483015291517f00000000000000000000000000000000000000000000000000000000000000009092169163c9c65396916044808201926020929091908290030181600087803b1580156150e557600080fd5b505af11580156150f9573d6000803e3d6000fd5b505050506040513d602081101561510f57600080fd5b50505b6000806151407f00000000000000000000000000000000000000000000000000000000000000008b8b61535b565b91509150816000148015615152575080155b1561516257879350869250615256565b600061516f898484614d2f565b90508781116151dc57858110156151d1576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b889450925082615254565b60006151e9898486614d2f565b9050898111156151f557fe5b8781101561524e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b94508793505b505b5050965096945050505050565b600081158061527e5750508082028282828161527b57fe5b04145b6113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6d756c2d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b808201828110156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6164642d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b600080600061536a8585614e0f565b50905060008061537b888888614135565b73ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156153c057600080fd5b505afa1580156153d4573d6000803e3d6000fd5b505050506040513d60608110156153ea57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905073ffffffffffffffffffffffffffffffffffffffff87811690841614615431578082615434565b81815b90999098509650505050505050565b6000811561545d57615456858585613e8a565b9050610f64565b600085116154b6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b6000841180156154c65750600083115b61551b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061552f866103e863ffffffff61526316565b90506000615543828663ffffffff61526316565b90506000615559876103e863ffffffff61526316565b905080828161556457fe5b0498975050505050505050565b6000811561558457615456858585614c0b565b600085116155dd576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b6000841180156155ed5750600083115b615642576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061565a6103e8614ce2878963ffffffff61526316565b90506000613f97856103e863ffffffff6152631656fe556e697377617056324c6962726172793a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a7472616e7366657246726f6d3a207472616e7366657246726f6d206661696c65645472616e7366657248656c7065723a3a736166655472616e736665724554483a20455448207472616e73666572206661696c6564556e697377617056324c6962726172793a204944454e544943414c5f414444524553534553556e69737761705632526f757465723a20494e53554646494349454e545f425f414d4f554e54556e697377617056324c6962726172793a20494e53554646494349454e545f4c4951554944495459556e697377617056324c6962726172793a20494e53554646494349454e545f414d4f554e54556e69737761705632526f757465723a204558434553534956455f494e5055545f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f415f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a736166655472616e736665723a207472616e73666572206661696c6564556e697377617056324c6962726172793a20494e53554646494349454e545f494e5055545f414d4f554e54a2646970667358221220727ddc3491766f9b8dc46e1c4bafbfdb094815ade2af57a4703d38a9b8e4709c64736f6c63430006060033",
+      "opcodes": "PUSH1 0x80 PUSH1 0x40 MSTORE PUSH1 0x4 CALLDATASIZE LT PUSH2 0x19A JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x8803DBEE GT PUSH2 0xE1 JUMPI DUP1 PUSH4 0xC45A0155 GT PUSH2 0x8A JUMPI DUP1 PUSH4 0xDED9382A GT PUSH2 0x64 JUMPI DUP1 PUSH4 0xDED9382A EQ PUSH2 0xC11 JUMPI DUP1 PUSH4 0xE8E33700 EQ PUSH2 0xC91 JUMPI DUP1 PUSH4 0xF305D719 EQ PUSH2 0xD1E JUMPI DUP1 PUSH4 0xFB3BDB41 EQ PUSH2 0xD71 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0xC45A0155 EQ PUSH2 0xB30 JUMPI DUP1 PUSH4 0xCAA0C28C EQ PUSH2 0xB45 JUMPI DUP1 PUSH4 0xD06CA61F EQ PUSH2 0xB5A JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0xAF2979EB GT PUSH2 0xBB JUMPI DUP1 PUSH4 0xAF2979EB EQ PUSH2 0x9D3 JUMPI DUP1 PUSH4 0xB6F9DE95 EQ PUSH2 0xA33 JUMPI DUP1 PUSH4 0xBAA2ABDE EQ PUSH2 0xAC6 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x8803DBEE EQ PUSH2 0x8BA JUMPI DUP1 PUSH4 0xAD5C4648 EQ PUSH2 0x95F JUMPI DUP1 PUSH4 0xAD615DEC EQ PUSH2 0x99D JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x4A25D94A GT PUSH2 0x143 JUMPI DUP1 PUSH4 0x791AC947 GT PUSH2 0x11D JUMPI DUP1 PUSH4 0x791AC947 EQ PUSH2 0x74C JUMPI DUP1 PUSH4 0x7FF36AB5 EQ PUSH2 0x7F1 JUMPI DUP1 PUSH4 0x85F8C259 EQ PUSH2 0x884 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x4A25D94A EQ PUSH2 0x582 JUMPI DUP1 PUSH4 0x5B0D5984 EQ PUSH2 0x627 JUMPI DUP1 PUSH4 0x5C11D795 EQ PUSH2 0x6A7 JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x1F00CA74 GT PUSH2 0x174 JUMPI DUP1 PUSH4 0x1F00CA74 EQ PUSH2 0x39B JUMPI DUP1 PUSH4 0x2195995C EQ PUSH2 0x452 JUMPI DUP1 PUSH4 0x38ED1739 EQ PUSH2 0x4DD JUMPI PUSH2 0x1E0 JUMP JUMPDEST DUP1 PUSH4 0x2751CEC EQ PUSH2 0x1E5 JUMPI DUP1 PUSH4 0x54D50D4 EQ PUSH2 0x25E JUMPI DUP1 PUSH4 0x18CBAFE5 EQ PUSH2 0x2A6 JUMPI PUSH2 0x1E0 JUMP JUMPDEST CALLDATASIZE PUSH2 0x1E0 JUMPI CALLER PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND EQ PUSH2 0x1DE JUMPI INVALID JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x1F1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0x208 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0xE04 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP3 DUP4 MSTORE PUSH1 0x20 DUP4 ADD SWAP2 SWAP1 SWAP2 MSTORE DUP1 MLOAD SWAP2 DUP3 SWAP1 SUB ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x26A JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x281 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0xF57 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP2 DUP3 MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x20 ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x2B2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x2C9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x2F0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x302 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x324 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0xF6C JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP1 DUP3 MSTORE DUP4 MLOAD DUP2 DUP4 ADD MSTORE DUP4 MLOAD SWAP2 SWAP3 DUP4 SWAP3 SWAP1 DUP4 ADD SWAP2 DUP6 DUP2 ADD SWAP2 MUL DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x387 JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x36F JUMP JUMPDEST POP POP POP POP SWAP1 POP ADD SWAP3 POP POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x3A7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x40 DUP2 LT ISZERO PUSH2 0x3BE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x3E0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x3F2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x414 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP1 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP SWAP3 SWAP6 POP PUSH2 0x138D SWAP5 POP POP POP POP POP JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x45E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x160 DUP2 LT ISZERO PUSH2 0x476 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 SWAP2 AND SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xE0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH2 0x100 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x120 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x140 ADD CALLDATALOAD PUSH2 0x13CB JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x4E9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x500 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x527 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x539 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x55B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1509 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x58E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x5A5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x5CC JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x5DE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x600 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x169E JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x633 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x140 DUP2 LT ISZERO PUSH2 0x64B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH1 0xE0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x100 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x120 ADD CALLDATALOAD PUSH2 0x18E5 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x6B3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x6CA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x6F1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x703 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x725 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1A37 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x758 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x76F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x796 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x7A8 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x7CA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x1DD0 JUMP JUMPDEST PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0x807 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x829 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x83B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x85D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x213E JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x890 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x8A7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0x2562 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x8C6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xA0 DUP2 LT ISZERO PUSH2 0x8DD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 DUP2 ADD SWAP1 PUSH1 0x60 DUP2 ADD PUSH1 0x40 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0x904 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0x916 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0x938 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x256F JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x96B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x26B2 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP1 SWAP3 AND DUP3 MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x20 ADD SWAP1 RETURN JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x9A9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x9C0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0x40 ADD CALLDATALOAD PUSH2 0x26D6 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0x9DF JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x294 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0x9F6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0x26E3 JUMP JUMPDEST PUSH2 0x1DE PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0xA49 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xA6B JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xA7D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xA9F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x28C3 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xAD2 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xE0 DUP2 LT ISZERO PUSH2 0xAE9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 SWAP2 AND SWAP1 PUSH1 0xC0 ADD CALLDATALOAD PUSH2 0x2DA6 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB3C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x30B0 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB51 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x974 PUSH2 0x30D4 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xB66 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x40 DUP2 LT ISZERO PUSH2 0xB7D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xB9F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xBB1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xBD3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP1 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP SWAP3 SWAP6 POP PUSH2 0x30F0 SWAP5 POP POP POP POP POP JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xC1D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0x245 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x140 DUP2 LT ISZERO PUSH2 0xC35 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP1 PUSH1 0xC0 DUP2 ADD CALLDATALOAD ISZERO ISZERO SWAP1 PUSH1 0xFF PUSH1 0xE0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH2 0x100 DUP2 ADD CALLDATALOAD SWAP1 PUSH2 0x120 ADD CALLDATALOAD PUSH2 0x3120 JUMP JUMPDEST CALLVALUE DUP1 ISZERO PUSH2 0xC9D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH2 0xD00 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH2 0x100 DUP2 LT ISZERO PUSH2 0xCB5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD DUP3 AND SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0xA0 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0xC0 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xE0 ADD CALLDATALOAD PUSH2 0x3278 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD SWAP4 DUP5 MSTORE PUSH1 0x20 DUP5 ADD SWAP3 SWAP1 SWAP3 MSTORE DUP3 DUP3 ADD MSTORE MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x60 ADD SWAP1 RETURN JUMPDEST PUSH2 0xD00 PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0xC0 DUP2 LT ISZERO PUSH2 0xD34 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD DUP2 AND SWAP2 PUSH1 0x20 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x40 DUP3 ADD CALLDATALOAD SWAP2 PUSH1 0x60 DUP2 ADD CALLDATALOAD SWAP2 PUSH1 0x80 DUP3 ADD CALLDATALOAD AND SWAP1 PUSH1 0xA0 ADD CALLDATALOAD PUSH2 0x3407 JUMP JUMPDEST PUSH2 0x34B PUSH1 0x4 DUP1 CALLDATASIZE SUB PUSH1 0x80 DUP2 LT ISZERO PUSH2 0xD87 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP2 CALLDATALOAD SWAP2 SWAP1 DUP2 ADD SWAP1 PUSH1 0x40 DUP2 ADD PUSH1 0x20 DUP3 ADD CALLDATALOAD PUSH5 0x100000000 DUP2 GT ISZERO PUSH2 0xDA9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP3 ADD DUP4 PUSH1 0x20 DUP3 ADD GT ISZERO PUSH2 0xDBB JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST DUP1 CALLDATALOAD SWAP1 PUSH1 0x20 ADD SWAP2 DUP5 PUSH1 0x20 DUP4 MUL DUP5 ADD GT PUSH5 0x100000000 DUP4 GT OR ISZERO PUSH2 0xDDD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP2 SWAP4 POP SWAP2 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 CALLDATALOAD AND SWAP1 PUSH1 0x20 ADD CALLDATALOAD PUSH2 0x3733 JUMP JUMPDEST PUSH1 0x0 DUP1 DUP3 TIMESTAMP DUP2 LT ISZERO PUSH2 0xE77 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0xEA6 DUP10 PUSH32 0x0 DUP11 DUP11 DUP11 ADDRESS DUP11 PUSH2 0x2DA6 JUMP JUMPDEST SWAP1 SWAP4 POP SWAP2 POP PUSH2 0xEB6 DUP10 DUP7 DUP6 PUSH2 0x3B86 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0xF29 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0xF3D JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0xF4B DUP6 DUP4 PUSH2 0x3D4D JUMP JUMPDEST POP SWAP7 POP SWAP7 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x3E8A JUMP JUMPDEST SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0xFDE JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1043 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x10E2 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1149 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST PUSH2 0x3FCD JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x115C JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x11BB JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH2 0x1280 DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x11CB JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER PUSH2 0x1266 PUSH32 0x0 DUP11 DUP11 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x121A JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP12 DUP12 PUSH1 0x1 DUP2 DUP2 LT PUSH2 0x1244 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH2 0x4135 JUMP JUMPDEST DUP6 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x1273 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x4220 JUMP JUMPDEST PUSH2 0x12BF DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP ADDRESS SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x1 DUP6 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x130B JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1349 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x135D JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1382 DUP5 DUP4 PUSH1 0x1 DUP6 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x1375 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x3D4D JUMP JUMPDEST POP SWAP7 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x60 PUSH2 0x13C2 PUSH32 0x0 DUP5 DUP5 PUSH2 0x13BD PUSH2 0x3FAE JUMP JUMPDEST PUSH2 0x4677 JUMP JUMPDEST SWAP1 POP JUMPDEST SWAP3 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x13FB PUSH32 0x0 DUP16 DUP16 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP8 PUSH2 0x140A JUMPI DUP13 PUSH2 0x142C JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP13 SWAP1 MSTORE PUSH1 0xFF DUP11 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP10 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP9 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x14C8 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x14DC JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x14EF DUP16 DUP16 DUP16 DUP16 DUP16 DUP16 DUP16 PUSH2 0x2DA6 JUMP JUMPDEST DUP1 SWAP5 POP DUP2 SWAP6 POP POP POP POP POP SWAP12 POP SWAP12 SWAP10 POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x157B JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x15DD PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x15F0 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x164F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH2 0x165F DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x11CB JUMPI INVALID JUMPDEST PUSH2 0x1382 DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1710 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1775 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x1814 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1876 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x1886 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x11BB JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 PUSH2 0x1933 PUSH32 0x0 DUP14 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP7 PUSH2 0x1942 JUMPI DUP12 PUSH2 0x1964 JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP12 SWAP1 MSTORE PUSH1 0xFF DUP10 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP9 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP8 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1A00 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x1A14 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1A26 DUP14 DUP14 DUP14 DUP14 DUP14 DUP14 PUSH2 0x26E3 JUMP JUMPDEST SWAP14 SWAP13 POP POP POP POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1AA7 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1B36 DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1AB7 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER PUSH2 0x1B30 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP11 DUP11 PUSH1 0x1 DUP2 DUP2 LT PUSH2 0x1244 JUMPI INVALID JUMPDEST DUP11 PUSH2 0x4220 JUMP JUMPDEST PUSH1 0x0 DUP6 DUP6 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1B66 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP6 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1BFF JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x1C13 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x1C29 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP9 DUP2 MUL DUP3 DUP2 ADD DUP3 ADD SWAP1 SWAP4 MSTORE DUP9 DUP3 MSTORE SWAP3 SWAP4 POP PUSH2 0x1C6B SWAP3 SWAP1 SWAP2 DUP10 SWAP2 DUP10 SWAP2 DUP3 SWAP2 DUP6 ADD SWAP1 DUP5 SWAP1 DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP9 SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST DUP7 PUSH2 0x1D6F DUP3 DUP9 DUP9 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1C9E JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x1D4B JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x1D61 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x4B99 AND JUMP JUMPDEST LT ISZERO PUSH2 0x1DC6 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x1E40 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND DUP6 DUP6 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x1EA5 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x1F44 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x1F54 DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1AB7 JUMPI INVALID JUMPDEST PUSH2 0x1F92 DUP6 DUP6 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP ADDRESS SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x70A0823100000000000000000000000000000000000000000000000000000000 DUP2 MSTORE ADDRESS PUSH1 0x4 DUP3 ADD MSTORE SWAP1 MLOAD PUSH1 0x0 SWAP2 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF PUSH32 0x0 AND SWAP2 PUSH4 0x70A08231 SWAP2 PUSH1 0x24 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2022 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2036 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x204C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP1 POP DUP7 DUP2 LT ISZERO PUSH2 0x20A9 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP3 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x211C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2130 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1DC6 DUP5 DUP3 PUSH2 0x3D4D JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x21B0 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x21F4 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2293 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x22F5 PUSH32 0x0 CALLVALUE DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x1144 SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x1 DUP5 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x2308 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD LT ISZERO PUSH2 0x2367 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57E7 PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x23B0 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x23E3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x23F7 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x2469 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP5 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x2476 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x24E7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x24FB JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2511 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x2519 JUMPI INVALID JUMPDEST PUSH2 0x2558 DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST POP SWAP6 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x4C0B JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x25E1 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x2643 PUSH32 0x0 DUP10 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP DUP7 DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x2653 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x164F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 DUP2 JUMP JUMPDEST PUSH1 0x0 PUSH2 0xF64 DUP5 DUP5 DUP5 PUSH2 0x4D2F JUMP JUMPDEST PUSH1 0x0 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2755 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x2784 DUP9 PUSH32 0x0 DUP10 DUP10 DUP10 ADDRESS DUP10 PUSH2 0x2DA6 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x70A0823100000000000000000000000000000000000000000000000000000000 DUP2 MSTORE ADDRESS PUSH1 0x4 DUP3 ADD MSTORE SWAP1 MLOAD SWAP2 SWAP5 POP PUSH2 0x282E SWAP3 POP DUP11 SWAP2 DUP8 SWAP2 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0x70A08231 SWAP2 PUSH1 0x24 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x27FD JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2811 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2827 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3B86 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x2E1A7D4D DUP4 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x28A1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x28B5 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x1382 DUP5 DUP4 PUSH2 0x3D4D JUMP JUMPDEST DUP1 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2933 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP6 DUP6 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x2977 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2A16 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 CALLVALUE SWAP1 POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP3 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2A83 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2A97 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x2B09 PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP4 PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2B73 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2B87 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2B9D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x2BA5 JUMPI INVALID JUMPDEST PUSH1 0x0 DUP7 DUP7 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x2BD5 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP7 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2C6E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x2C82 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2C98 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH1 0x40 DUP1 MLOAD PUSH1 0x20 DUP10 DUP2 MUL DUP3 DUP2 ADD DUP3 ADD SWAP1 SWAP4 MSTORE DUP10 DUP3 MSTORE SWAP3 SWAP4 POP PUSH2 0x2CDA SWAP3 SWAP1 SWAP2 DUP11 SWAP2 DUP11 SWAP2 DUP3 SWAP2 DUP6 ADD SWAP1 DUP5 SWAP1 DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x4806 SWAP2 POP POP JUMP JUMPDEST DUP8 PUSH2 0x1D6F DUP3 DUP10 DUP10 PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP2 ADD DUP2 DUP2 LT PUSH2 0x2D0D JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP10 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x0 DUP1 DUP3 TIMESTAMP DUP2 LT ISZERO PUSH2 0x2E19 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x2E46 PUSH32 0x0 DUP13 DUP13 PUSH2 0x4135 JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0x23B872DD00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP4 AND PUSH1 0x24 DUP3 ADD DUP2 SWAP1 MSTORE PUSH1 0x44 DUP3 ADD DUP14 SWAP1 MSTORE SWAP2 MLOAD SWAP3 SWAP4 POP SWAP1 SWAP2 PUSH4 0x23B872DD SWAP2 PUSH1 0x64 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2EC7 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2EDB JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x2EF1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP POP PUSH1 0x40 DUP1 MLOAD PUSH32 0x89AFCB4400000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP9 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP3 MLOAD PUSH1 0x0 SWAP4 DUP5 SWAP4 SWAP3 DUP7 AND SWAP3 PUSH4 0x89AFCB44 SWAP3 PUSH1 0x24 DUP1 DUP4 ADD SWAP4 SWAP3 DUP3 SWAP1 SUB ADD DUP2 DUP8 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x2F64 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x2F78 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x40 DUP2 LT ISZERO PUSH2 0x2F8E JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD SWAP1 SWAP3 POP SWAP1 POP PUSH1 0x0 PUSH2 0x2FA8 DUP15 DUP15 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP15 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x2FE5 JUMPI DUP2 DUP4 PUSH2 0x2FE8 JUMP JUMPDEST DUP3 DUP3 JUMPDEST SWAP1 SWAP8 POP SWAP6 POP DUP11 DUP8 LT ISZERO PUSH2 0x3046 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57C1 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP10 DUP7 LT ISZERO PUSH2 0x309F JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5727 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP SWAP8 POP SWAP8 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH32 0x0 DUP2 JUMP JUMPDEST PUSH1 0x0 SLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 JUMP JUMPDEST PUSH1 0x60 PUSH2 0x13C2 PUSH32 0x0 DUP5 DUP5 PUSH2 0x1144 PUSH2 0x3FAE JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x3170 PUSH32 0x0 DUP15 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP8 PUSH2 0x317F JUMPI DUP13 PUSH2 0x31A1 JUMP JUMPDEST PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xD505ACCF00000000000000000000000000000000000000000000000000000000 DUP2 MSTORE CALLER PUSH1 0x4 DUP3 ADD MSTORE ADDRESS PUSH1 0x24 DUP3 ADD MSTORE PUSH1 0x44 DUP2 ADD DUP4 SWAP1 MSTORE PUSH1 0x64 DUP2 ADD DUP13 SWAP1 MSTORE PUSH1 0xFF DUP11 AND PUSH1 0x84 DUP3 ADD MSTORE PUSH1 0xA4 DUP2 ADD DUP10 SWAP1 MSTORE PUSH1 0xC4 DUP2 ADD DUP9 SWAP1 MSTORE SWAP1 MLOAD SWAP2 SWAP3 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP2 PUSH4 0xD505ACCF SWAP2 PUSH1 0xE4 DUP1 DUP3 ADD SWAP3 PUSH1 0x0 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP4 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x323D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3251 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH2 0x3263 DUP15 DUP15 DUP15 DUP15 DUP15 DUP15 PUSH2 0xE04 JUMP JUMPDEST SWAP1 SWAP16 SWAP1 SWAP15 POP SWAP13 POP POP POP POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 DUP4 TIMESTAMP DUP2 LT ISZERO PUSH2 0x32ED JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x32FB DUP13 DUP13 DUP13 DUP13 DUP13 DUP13 PUSH2 0x4F62 JUMP JUMPDEST SWAP1 SWAP5 POP SWAP3 POP PUSH1 0x0 PUSH2 0x332D PUSH32 0x0 DUP15 DUP15 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x333B DUP14 CALLER DUP4 DUP9 PUSH2 0x4220 JUMP JUMPDEST PUSH2 0x3347 DUP13 CALLER DUP4 DUP8 PUSH2 0x4220 JUMP JUMPDEST DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x6A627842 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x33C6 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x33DA JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x33F0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP5 SWAP14 SWAP4 SWAP13 POP SWAP4 SWAP11 POP SWAP2 SWAP9 POP POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 DUP4 TIMESTAMP DUP2 LT ISZERO PUSH2 0x347C JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x34AA DUP11 PUSH32 0x0 DUP12 CALLVALUE DUP13 DUP13 PUSH2 0x4F62 JUMP JUMPDEST SWAP1 SWAP5 POP SWAP3 POP PUSH1 0x0 PUSH2 0x34FC PUSH32 0x0 DUP13 PUSH32 0x0 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x350A DUP12 CALLER DUP4 DUP9 PUSH2 0x4220 JUMP JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP6 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3572 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3586 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB DUP3 DUP7 PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3632 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3646 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x365C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3664 JUMPI INVALID JUMPDEST DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x6A627842 DUP9 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x36E3 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x36F7 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x370D JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD SWAP3 POP CALLVALUE DUP5 LT ISZERO PUSH2 0x3725 JUMPI PUSH2 0x3725 CALLER DUP6 CALLVALUE SUB PUSH2 0x3D4D JUMP JUMPDEST POP POP SWAP7 POP SWAP7 POP SWAP7 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x60 DUP2 TIMESTAMP DUP2 LT ISZERO PUSH2 0x37A5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x18 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20455850495245440000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 DUP7 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x37E9 JUMPI INVALID JUMPDEST SWAP1 POP PUSH1 0x20 MUL ADD CALLDATALOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x3888 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1D PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E69737761705632526F757465723A20494E56414C49445F50415448000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH2 0x38EA PUSH32 0x0 DUP9 DUP9 DUP9 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP PUSH2 0x13BD SWAP3 POP PUSH2 0x3FAE SWAP2 POP POP JUMP JUMPDEST SWAP2 POP CALLVALUE DUP3 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x38FA JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD GT ISZERO PUSH2 0x3959 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x27 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x579A PUSH1 0x27 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xD0E30DB0 DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x39A2 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP9 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x39D5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x39E9 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP POP PUSH32 0x0 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0xA9059CBB PUSH2 0x3A5B PUSH32 0x0 DUP10 DUP10 PUSH1 0x0 DUP2 DUP2 LT PUSH2 0x1B06 JUMPI INVALID JUMPDEST DUP5 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3A68 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH1 0x40 MLOAD DUP4 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP3 DUP2 MSTORE PUSH1 0x20 ADD SWAP3 POP POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x3AD9 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x3AED JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x3B03 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH2 0x3B0B JUMPI INVALID JUMPDEST PUSH2 0x3B4A DUP3 DUP8 DUP8 DUP1 DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD PUSH1 0x40 MLOAD SWAP1 DUP2 ADD PUSH1 0x40 MSTORE DUP1 SWAP4 SWAP3 SWAP2 SWAP1 DUP2 DUP2 MSTORE PUSH1 0x20 ADD DUP4 DUP4 PUSH1 0x20 MUL DUP1 DUP3 DUP5 CALLDATACOPY PUSH1 0x0 SWAP3 ADD SWAP2 SWAP1 SWAP2 MSTORE POP DUP10 SWAP3 POP PUSH2 0x43F0 SWAP2 POP POP JUMP JUMPDEST DUP2 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3B57 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD CALLVALUE GT ISZERO PUSH2 0x2558 JUMPI PUSH2 0x2558 CALLER DUP4 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x3B77 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD CALLVALUE SUB PUSH2 0x3D4D JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE PUSH1 0x44 DUP1 DUP4 ADD DUP6 SWAP1 MSTORE DUP4 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0x64 SWAP1 SWAP3 ADD DUP4 MSTORE PUSH1 0x20 DUP3 ADD DUP1 MLOAD PUSH28 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH32 0xA9059CBB00000000000000000000000000000000000000000000000000000000 OR DUP2 MSTORE SWAP3 MLOAD DUP3 MLOAD PUSH1 0x0 SWAP5 PUSH1 0x60 SWAP5 SWAP4 DUP10 AND SWAP4 SWAP3 SWAP2 DUP3 SWAP2 SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x3C5C JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x3C1F JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP7 GAS CALL SWAP2 POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x3CBE JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x3CC3 JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP SWAP2 POP SWAP2 POP DUP2 DUP1 ISZERO PUSH2 0x3CF1 JUMPI POP DUP1 MLOAD ISZERO DUP1 PUSH2 0x3CF1 JUMPI POP DUP1 DUP1 PUSH1 0x20 ADD SWAP1 MLOAD PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x3CEE JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD JUMPDEST PUSH2 0x3D46 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2D DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5812 PUSH1 0x2D SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x0 DUP1 DUP3 MSTORE PUSH1 0x20 DUP3 ADD SWAP1 SWAP3 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP5 AND SWAP1 DUP4 SWAP1 PUSH1 0x40 MLOAD DUP1 DUP3 DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x3DC4 JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x3D87 JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP6 DUP8 GAS CALL SWAP3 POP POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x3E26 JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x3E2B JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP POP SWAP1 POP DUP1 PUSH2 0x3E85 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x34 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x56CE PUSH1 0x34 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x3EE4 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x583F PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x3EF4 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x3F49 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x3F5D DUP6 PUSH2 0x3E5 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F71 DUP3 DUP6 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F97 DUP4 PUSH2 0x3F8B DUP9 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x52E9 AND JUMP JUMPDEST SWAP1 POP DUP1 DUP3 DUP2 PUSH2 0x3FA2 JUMPI INVALID JUMPDEST DIV SWAP8 SWAP7 POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 SLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND CALLER EQ ISZERO SWAP1 JUMP JUMPDEST PUSH1 0x60 PUSH1 0x2 DUP4 MLOAD LT ISZERO PUSH2 0x4040 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A20494E56414C49445F504154480000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP3 MLOAD PUSH8 0xFFFFFFFFFFFFFFFF DUP2 GT DUP1 ISZERO PUSH2 0x4058 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x4082 JUMPI DUP2 PUSH1 0x20 ADD PUSH1 0x20 DUP3 MUL DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP SWAP1 POP DUP4 DUP2 PUSH1 0x0 DUP2 MLOAD DUP2 LT PUSH2 0x4093 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD DUP2 DUP2 MSTORE POP POP PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP5 MLOAD SUB DUP2 LT ISZERO PUSH2 0x412C JUMPI PUSH1 0x0 DUP1 PUSH2 0x40E5 DUP9 DUP8 DUP6 DUP2 MLOAD DUP2 LT PUSH2 0x40C1 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP9 DUP7 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x40D8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x535B JUMP JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x4108 DUP5 DUP5 DUP2 MLOAD DUP2 LT PUSH2 0x40F8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP4 DUP4 DUP9 PUSH2 0x5443 JUMP JUMPDEST DUP5 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4117 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE POP POP PUSH1 0x1 ADD PUSH2 0x40A2 JUMP JUMPDEST POP SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x4144 DUP6 DUP6 PUSH2 0x4E0F JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000 PUSH1 0x60 SWAP5 DUP6 SHL DUP2 AND PUSH1 0x20 DUP1 DUP5 ADD SWAP2 SWAP1 SWAP2 MSTORE SWAP4 DUP6 SHL DUP2 AND PUSH1 0x34 DUP4 ADD MSTORE DUP3 MLOAD PUSH1 0x28 DUP2 DUP5 SUB ADD DUP2 MSTORE PUSH1 0x48 DUP4 ADD DUP5 MSTORE DUP1 MLOAD SWAP1 DUP6 ADD KECCAK256 PUSH32 0xFF00000000000000000000000000000000000000000000000000000000000000 PUSH1 0x68 DUP5 ADD MSTORE SWAP11 SWAP1 SWAP5 SHL SWAP1 SWAP4 AND PUSH1 0x69 DUP5 ADD MSTORE PUSH1 0x7D DUP4 ADD SWAP9 SWAP1 SWAP9 MSTORE PUSH32 0x96E8AC4277198FF8B6F785478AA9A39F403CB768DD02CBEE326C3E7DA348845F PUSH1 0x9D DUP1 DUP5 ADD SWAP2 SWAP1 SWAP2 MSTORE DUP9 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0xBD SWAP1 SWAP3 ADD SWAP1 SWAP8 MSTORE DUP1 MLOAD SWAP7 ADD SWAP6 SWAP1 SWAP6 KECCAK256 SWAP6 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP6 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE DUP5 DUP2 AND PUSH1 0x44 DUP4 ADD MSTORE PUSH1 0x64 DUP1 DUP4 ADD DUP6 SWAP1 MSTORE DUP4 MLOAD DUP1 DUP5 SUB SWAP1 SWAP2 ADD DUP2 MSTORE PUSH1 0x84 SWAP1 SWAP3 ADD DUP4 MSTORE PUSH1 0x20 DUP3 ADD DUP1 MLOAD PUSH28 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH32 0x23B872DD00000000000000000000000000000000000000000000000000000000 OR DUP2 MSTORE SWAP3 MLOAD DUP3 MLOAD PUSH1 0x0 SWAP5 PUSH1 0x60 SWAP5 SWAP4 DUP11 AND SWAP4 SWAP3 SWAP2 DUP3 SWAP2 SWAP1 DUP1 DUP4 DUP4 JUMPDEST PUSH1 0x20 DUP4 LT PUSH2 0x42FE JUMPI DUP1 MLOAD DUP3 MSTORE PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 SWAP1 SWAP3 ADD SWAP2 PUSH1 0x20 SWAP2 DUP3 ADD SWAP2 ADD PUSH2 0x42C1 JUMP JUMPDEST PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB DUP1 NOT DUP3 MLOAD AND DUP2 DUP5 MLOAD AND DUP1 DUP3 OR DUP6 MSTORE POP POP POP POP POP POP SWAP1 POP ADD SWAP2 POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP7 GAS CALL SWAP2 POP POP RETURNDATASIZE DUP1 PUSH1 0x0 DUP2 EQ PUSH2 0x4360 JUMPI PUSH1 0x40 MLOAD SWAP2 POP PUSH1 0x1F NOT PUSH1 0x3F RETURNDATASIZE ADD AND DUP3 ADD PUSH1 0x40 MSTORE RETURNDATASIZE DUP3 MSTORE RETURNDATASIZE PUSH1 0x0 PUSH1 0x20 DUP5 ADD RETURNDATACOPY PUSH2 0x4365 JUMP JUMPDEST PUSH1 0x60 SWAP2 POP JUMPDEST POP SWAP2 POP SWAP2 POP DUP2 DUP1 ISZERO PUSH2 0x4393 JUMPI POP DUP1 MLOAD ISZERO DUP1 PUSH2 0x4393 JUMPI POP DUP1 DUP1 PUSH1 0x20 ADD SWAP1 MLOAD PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x4390 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD JUMPDEST PUSH2 0x43E8 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x31 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x569D PUSH1 0x31 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP4 MLOAD SUB DUP2 LT ISZERO PUSH2 0x4671 JUMPI PUSH1 0x0 DUP1 DUP5 DUP4 DUP2 MLOAD DUP2 LT PUSH2 0x440E JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP6 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4425 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH2 0x443D DUP4 DUP4 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 DUP8 DUP6 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x4451 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP1 POP PUSH1 0x0 DUP1 DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP7 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x4499 JUMPI DUP3 PUSH1 0x0 PUSH2 0x449D JUMP JUMPDEST PUSH1 0x0 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH1 0x2 DUP11 MLOAD SUB DUP9 LT PUSH2 0x44B4 JUMPI DUP9 PUSH2 0x44F5 JUMP JUMPDEST PUSH2 0x44F5 PUSH32 0x0 DUP8 DUP13 DUP12 PUSH1 0x2 ADD DUP2 MLOAD DUP2 LT PUSH2 0x44E8 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH2 0x4522 PUSH32 0x0 DUP9 DUP9 PUSH2 0x4135 JUMP JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x22C0D9F DUP5 DUP5 DUP5 PUSH1 0x0 PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x1F ADD PUSH1 0x1F NOT AND PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x456C JUMPI PUSH1 0x20 DUP3 ADD DUP2 DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP PUSH1 0x40 MLOAD DUP6 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP6 DUP2 MSTORE PUSH1 0x20 ADD DUP5 DUP2 MSTORE PUSH1 0x20 ADD DUP4 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE DUP4 DUP2 DUP2 MLOAD DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP DUP1 MLOAD SWAP1 PUSH1 0x20 ADD SWAP1 DUP1 DUP4 DUP4 PUSH1 0x0 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x45F7 JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x45DF JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0x4624 JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP SWAP6 POP POP POP POP POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x4646 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x465A JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP PUSH1 0x1 SWAP1 SWAP10 ADD SWAP9 POP PUSH2 0x43F3 SWAP8 POP POP POP POP POP POP POP POP JUMP JUMPDEST POP POP POP POP JUMP JUMPDEST PUSH1 0x60 PUSH1 0x2 DUP4 MLOAD LT ISZERO PUSH2 0x46EA JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A20494E56414C49445F504154480000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP3 MLOAD PUSH8 0xFFFFFFFFFFFFFFFF DUP2 GT DUP1 ISZERO PUSH2 0x4702 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x40 MLOAD SWAP1 DUP1 DUP3 MSTORE DUP1 PUSH1 0x20 MUL PUSH1 0x20 ADD DUP3 ADD PUSH1 0x40 MSTORE DUP1 ISZERO PUSH2 0x472C JUMPI DUP2 PUSH1 0x20 ADD PUSH1 0x20 DUP3 MUL DUP1 CALLDATASIZE DUP4 CALLDATACOPY ADD SWAP1 POP JUMPDEST POP SWAP1 POP DUP4 DUP2 PUSH1 0x1 DUP4 MLOAD SUB DUP2 MLOAD DUP2 LT PUSH2 0x4740 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE DUP3 MLOAD PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF ADD JUMPDEST DUP1 ISZERO PUSH2 0x412C JUMPI PUSH1 0x0 DUP1 PUSH2 0x47A0 DUP9 DUP8 PUSH1 0x1 DUP7 SUB DUP2 MLOAD DUP2 LT PUSH2 0x478C JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP9 DUP7 DUP2 MLOAD DUP2 LT PUSH2 0x40D8 JUMPI INVALID JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x47C3 DUP5 DUP5 DUP2 MLOAD DUP2 LT PUSH2 0x47B3 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP4 DUP4 DUP9 PUSH2 0x5571 JUMP JUMPDEST DUP5 PUSH1 0x1 DUP6 SUB DUP2 MLOAD DUP2 LT PUSH2 0x47D2 JUMPI INVALID JUMPDEST PUSH1 0x20 SWAP1 DUP2 MUL SWAP2 SWAP1 SWAP2 ADD ADD MSTORE POP POP PUSH32 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF ADD PUSH2 0x4770 JUMP JUMPDEST PUSH1 0x0 JUMPDEST PUSH1 0x1 DUP4 MLOAD SUB DUP2 LT ISZERO PUSH2 0x3E85 JUMPI PUSH1 0x0 DUP1 DUP5 DUP4 DUP2 MLOAD DUP2 LT PUSH2 0x4824 JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD DUP6 DUP5 PUSH1 0x1 ADD DUP2 MLOAD DUP2 LT PUSH2 0x483B JUMPI INVALID JUMPDEST PUSH1 0x20 MUL PUSH1 0x20 ADD ADD MLOAD SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH2 0x4853 DUP4 DUP4 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 PUSH2 0x4883 PUSH32 0x0 DUP6 DUP6 PUSH2 0x4135 JUMP JUMPDEST SWAP1 POP PUSH1 0x0 DUP1 PUSH1 0x0 DUP1 DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x902F1AC PUSH1 0x40 MLOAD DUP2 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x60 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x48D1 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x48E5 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x48FB JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD PUSH14 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP2 DUP3 AND SWAP4 POP AND SWAP1 POP PUSH1 0x0 DUP1 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP11 DUP2 AND SWAP1 DUP10 AND EQ PUSH2 0x4945 JUMPI DUP3 DUP5 PUSH2 0x4948 JUMP JUMPDEST DUP4 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH2 0x49CD DUP3 DUP12 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x70A08231 DUP11 PUSH1 0x40 MLOAD DUP3 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP POP PUSH1 0x20 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x1D37 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST SWAP6 POP PUSH2 0x49DA DUP7 DUP4 DUP4 PUSH2 0x3E8A JUMP JUMPDEST SWAP5 POP POP POP POP POP PUSH1 0x0 DUP1 DUP6 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP9 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ PUSH2 0x4A1E JUMPI DUP3 PUSH1 0x0 PUSH2 0x4A22 JUMP JUMPDEST PUSH1 0x0 DUP4 JUMPDEST SWAP2 POP SWAP2 POP PUSH1 0x0 PUSH1 0x2 DUP13 MLOAD SUB DUP11 LT PUSH2 0x4A39 JUMPI DUP11 PUSH2 0x4A6D JUMP JUMPDEST PUSH2 0x4A6D PUSH32 0x0 DUP10 DUP15 DUP14 PUSH1 0x2 ADD DUP2 MLOAD DUP2 LT PUSH2 0x44E8 JUMPI INVALID JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH1 0x0 DUP1 DUP3 MSTORE PUSH1 0x20 DUP3 ADD SWAP3 DUP4 SWAP1 MSTORE PUSH32 0x22C0D9F00000000000000000000000000000000000000000000000000000000 DUP4 MSTORE PUSH1 0x24 DUP3 ADD DUP8 DUP2 MSTORE PUSH1 0x44 DUP4 ADD DUP8 SWAP1 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP1 DUP7 AND PUSH1 0x64 DUP6 ADD MSTORE PUSH1 0x80 PUSH1 0x84 DUP6 ADD SWAP1 DUP2 MSTORE DUP5 MLOAD PUSH1 0xA4 DUP7 ADD DUP2 SWAP1 MSTORE SWAP7 SWAP8 POP SWAP1 DUP13 AND SWAP6 PUSH4 0x22C0D9F SWAP6 DUP11 SWAP6 DUP11 SWAP6 DUP11 SWAP6 SWAP2 SWAP5 SWAP2 SWAP4 SWAP2 SWAP3 PUSH1 0xC4 DUP7 ADD SWAP3 SWAP1 SWAP2 DUP2 SWAP1 DUP5 SWAP1 DUP5 SWAP1 JUMPDEST DUP4 DUP2 LT ISZERO PUSH2 0x4B1D JUMPI DUP2 DUP2 ADD MLOAD DUP4 DUP3 ADD MSTORE PUSH1 0x20 ADD PUSH2 0x4B05 JUMP JUMPDEST POP POP POP POP SWAP1 POP SWAP1 DUP2 ADD SWAP1 PUSH1 0x1F AND DUP1 ISZERO PUSH2 0x4B4A JUMPI DUP1 DUP3 SUB DUP1 MLOAD PUSH1 0x1 DUP4 PUSH1 0x20 SUB PUSH2 0x100 EXP SUB NOT AND DUP2 MSTORE PUSH1 0x20 ADD SWAP2 POP JUMPDEST POP SWAP6 POP POP POP POP POP POP PUSH1 0x0 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x4B6C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x4B80 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP PUSH1 0x1 SWAP1 SWAP12 ADD SWAP11 POP PUSH2 0x4809 SWAP10 POP POP POP POP POP POP POP POP POP POP JUMP JUMPDEST DUP1 DUP3 SUB DUP3 DUP2 GT ISZERO PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x15 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D7375622D756E646572666C6F770000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x4C65 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2C DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5671 PUSH1 0x2C SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x4C75 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x4CCA JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x4CEE PUSH2 0x3E8 PUSH2 0x4CE2 DUP7 DUP9 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x4D08 PUSH2 0x3E5 PUSH2 0x4CE2 DUP7 DUP10 PUSH4 0xFFFFFFFF PUSH2 0x4B99 AND JUMP JUMPDEST SWAP1 POP PUSH2 0x4D25 PUSH1 0x1 DUP3 DUP5 DUP2 PUSH2 0x4D18 JUMPI INVALID JUMPDEST DIV SWAP1 PUSH4 0xFFFFFFFF PUSH2 0x52E9 AND JUMP JUMPDEST SWAP7 SWAP6 POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP5 GT PUSH2 0x4D89 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x25 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5775 PUSH1 0x25 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP4 GT DUP1 ISZERO PUSH2 0x4D99 JUMPI POP PUSH1 0x0 DUP3 GT JUMPDEST PUSH2 0x4DEE JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP3 PUSH2 0x4DFF DUP6 DUP5 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST DUP2 PUSH2 0x4E06 JUMPI INVALID JUMPDEST DIV SWAP5 SWAP4 POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP1 DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ ISZERO PUSH2 0x4E97 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x25 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5702 PUSH1 0x25 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP3 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND DUP5 PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND LT PUSH2 0x4ED1 JUMPI DUP3 DUP5 PUSH2 0x4ED4 JUMP JUMPDEST DUP4 DUP4 JUMPDEST SWAP1 SWAP3 POP SWAP1 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP3 AND PUSH2 0x4F5B JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x1E PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x556E697377617056324C6962726172793A205A45524F5F414444524553530000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST SWAP3 POP SWAP3 SWAP1 POP JUMP JUMPDEST PUSH1 0x40 DUP1 MLOAD PUSH32 0xE6A4390500000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP9 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP8 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE SWAP2 MLOAD PUSH1 0x0 SWAP3 DUP4 SWAP3 DUP4 SWAP3 PUSH32 0x0 SWAP1 SWAP3 AND SWAP2 PUSH4 0xE6A43905 SWAP2 PUSH1 0x44 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x5002 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x5016 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x502C JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP MLOAD PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND EQ ISZERO PUSH2 0x5112 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0xC9C6539600000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP11 DUP2 AND PUSH1 0x4 DUP4 ADD MSTORE DUP10 DUP2 AND PUSH1 0x24 DUP4 ADD MSTORE SWAP2 MLOAD PUSH32 0x0 SWAP1 SWAP3 AND SWAP2 PUSH4 0xC9C65396 SWAP2 PUSH1 0x44 DUP1 DUP3 ADD SWAP3 PUSH1 0x20 SWAP3 SWAP1 SWAP2 SWAP1 DUP3 SWAP1 SUB ADD DUP2 PUSH1 0x0 DUP8 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x50E5 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS CALL ISZERO DUP1 ISZERO PUSH2 0x50F9 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x20 DUP2 LT ISZERO PUSH2 0x510F JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP POP JUMPDEST PUSH1 0x0 DUP1 PUSH2 0x5140 PUSH32 0x0 DUP12 DUP12 PUSH2 0x535B JUMP JUMPDEST SWAP2 POP SWAP2 POP DUP2 PUSH1 0x0 EQ DUP1 ISZERO PUSH2 0x5152 JUMPI POP DUP1 ISZERO JUMPDEST ISZERO PUSH2 0x5162 JUMPI DUP8 SWAP4 POP DUP7 SWAP3 POP PUSH2 0x5256 JUMP JUMPDEST PUSH1 0x0 PUSH2 0x516F DUP10 DUP5 DUP5 PUSH2 0x4D2F JUMP JUMPDEST SWAP1 POP DUP8 DUP2 GT PUSH2 0x51DC JUMPI DUP6 DUP2 LT ISZERO PUSH2 0x51D1 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5727 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST DUP9 SWAP5 POP SWAP3 POP DUP3 PUSH2 0x5254 JUMP JUMPDEST PUSH1 0x0 PUSH2 0x51E9 DUP10 DUP5 DUP7 PUSH2 0x4D2F JUMP JUMPDEST SWAP1 POP DUP10 DUP2 GT ISZERO PUSH2 0x51F5 JUMPI INVALID JUMPDEST DUP8 DUP2 LT ISZERO PUSH2 0x524E JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x26 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x57C1 PUSH1 0x26 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST SWAP5 POP DUP8 SWAP4 POP JUMPDEST POP JUMPDEST POP POP SWAP7 POP SWAP7 SWAP5 POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO DUP1 PUSH2 0x527E JUMPI POP POP DUP1 DUP3 MUL DUP3 DUP3 DUP3 DUP2 PUSH2 0x527B JUMPI INVALID JUMPDEST DIV EQ JUMPDEST PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x14 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D6D756C2D6F766572666C6F77000000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST DUP1 DUP3 ADD DUP3 DUP2 LT ISZERO PUSH2 0x13C5 JUMPI PUSH1 0x40 DUP1 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x20 PUSH1 0x4 DUP3 ADD MSTORE PUSH1 0x14 PUSH1 0x24 DUP3 ADD MSTORE PUSH32 0x64732D6D6174682D6164642D6F766572666C6F77000000000000000000000000 PUSH1 0x44 DUP3 ADD MSTORE SWAP1 MLOAD SWAP1 DUP2 SWAP1 SUB PUSH1 0x64 ADD SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP1 PUSH1 0x0 PUSH2 0x536A DUP6 DUP6 PUSH2 0x4E0F JUMP JUMPDEST POP SWAP1 POP PUSH1 0x0 DUP1 PUSH2 0x537B DUP9 DUP9 DUP9 PUSH2 0x4135 JUMP JUMPDEST PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF AND PUSH4 0x902F1AC PUSH1 0x40 MLOAD DUP2 PUSH4 0xFFFFFFFF AND PUSH1 0xE0 SHL DUP2 MSTORE PUSH1 0x4 ADD PUSH1 0x60 PUSH1 0x40 MLOAD DUP1 DUP4 SUB DUP2 DUP7 DUP1 EXTCODESIZE ISZERO DUP1 ISZERO PUSH2 0x53C0 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP GAS STATICCALL ISZERO DUP1 ISZERO PUSH2 0x53D4 JUMPI RETURNDATASIZE PUSH1 0x0 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x0 REVERT JUMPDEST POP POP POP POP PUSH1 0x40 MLOAD RETURNDATASIZE PUSH1 0x60 DUP2 LT ISZERO PUSH2 0x53EA JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP DUP1 MLOAD PUSH1 0x20 SWAP1 SWAP2 ADD MLOAD PUSH14 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF SWAP2 DUP3 AND SWAP4 POP AND SWAP1 POP PUSH20 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF DUP8 DUP2 AND SWAP1 DUP5 AND EQ PUSH2 0x5431 JUMPI DUP1 DUP3 PUSH2 0x5434 JUMP JUMPDEST DUP2 DUP2 JUMPDEST SWAP1 SWAP10 SWAP1 SWAP9 POP SWAP7 POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO PUSH2 0x545D JUMPI PUSH2 0x5456 DUP6 DUP6 DUP6 PUSH2 0x3E8A JUMP JUMPDEST SWAP1 POP PUSH2 0xF64 JUMP JUMPDEST PUSH1 0x0 DUP6 GT PUSH2 0x54B6 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2B DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x583F PUSH1 0x2B SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP5 GT DUP1 ISZERO PUSH2 0x54C6 JUMPI POP PUSH1 0x0 DUP4 GT JUMPDEST PUSH2 0x551B JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x552F DUP7 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x5543 DUP3 DUP7 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x5559 DUP8 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP DUP1 DUP3 DUP2 PUSH2 0x5564 JUMPI INVALID JUMPDEST DIV SWAP9 SWAP8 POP POP POP POP POP POP POP POP JUMP JUMPDEST PUSH1 0x0 DUP2 ISZERO PUSH2 0x5584 JUMPI PUSH2 0x5456 DUP6 DUP6 DUP6 PUSH2 0x4C0B JUMP JUMPDEST PUSH1 0x0 DUP6 GT PUSH2 0x55DD JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x2C DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x5671 PUSH1 0x2C SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 DUP5 GT DUP1 ISZERO PUSH2 0x55ED JUMPI POP PUSH1 0x0 DUP4 GT JUMPDEST PUSH2 0x5642 JUMPI PUSH1 0x40 MLOAD PUSH32 0x8C379A000000000000000000000000000000000000000000000000000000000 DUP2 MSTORE PUSH1 0x4 ADD DUP1 DUP1 PUSH1 0x20 ADD DUP3 DUP2 SUB DUP3 MSTORE PUSH1 0x28 DUP2 MSTORE PUSH1 0x20 ADD DUP1 PUSH2 0x574D PUSH1 0x28 SWAP2 CODECOPY PUSH1 0x40 ADD SWAP2 POP POP PUSH1 0x40 MLOAD DUP1 SWAP2 SUB SWAP1 REVERT JUMPDEST PUSH1 0x0 PUSH2 0x565A PUSH2 0x3E8 PUSH2 0x4CE2 DUP8 DUP10 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP JUMPDEST SWAP1 POP PUSH1 0x0 PUSH2 0x3F97 DUP6 PUSH2 0x3E8 PUSH4 0xFFFFFFFF PUSH2 0x5263 AND JUMP INVALID SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4F SSTORE SLOAD POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SLOAD PUSH19 0x616E7366657248656C7065723A3A7472616E73 PUSH7 0x657246726F6D3A KECCAK256 PUSH21 0x72616E7366657246726F6D206661696C6564547261 PUSH15 0x7366657248656C7065723A3A736166 PUSH6 0x5472616E7366 PUSH6 0x724554483A20 GASLIMIT SLOAD 0x48 KECCAK256 PUSH21 0x72616E73666572206661696C6564556E6973776170 JUMP ORIGIN 0x4C PUSH10 0x62726172793A20494445 0x4E SLOAD 0x49 NUMBER COINBASE 0x4C 0x5F COINBASE DIFFICULTY DIFFICULTY MSTORE GASLIMIT MSTORE8 MSTORE8 GASLIMIT MSTORE8 SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F TIMESTAMP 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4C 0x49 MLOAD SSTORE 0x49 DIFFICULTY 0x49 SLOAD MSIZE SSTORE PUSH15 0x697377617056324C6962726172793A KECCAK256 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 GASLIMIT PC NUMBER GASLIMIT MSTORE8 MSTORE8 0x49 JUMP GASLIMIT 0x5F 0x49 0x4E POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F COINBASE 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SSTORE PUSH15 0x69737761705632526F757465723A20 0x49 0x4E MSTORE8 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x4F SSTORE SLOAD POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD SLOAD PUSH19 0x616E7366657248656C7065723A3A7361666554 PUSH19 0x616E736665723A207472616E73666572206661 PUSH10 0x6C6564556E6973776170 JUMP ORIGIN 0x4C PUSH10 0x62726172793A20494E53 SSTORE CHAINID CHAINID 0x49 NUMBER 0x49 GASLIMIT 0x4E SLOAD 0x5F 0x49 0x4E POP SSTORE SLOAD 0x5F COINBASE 0x4D 0x4F SSTORE 0x4E SLOAD LOG2 PUSH5 0x6970667358 0x22 SLT KECCAK256 PUSH19 0x7DDC3491766F9B8DC46E1C4BAFBFDB094815AD 0xE2 0xAF JUMPI LOG4 PUSH17 0x3D38A9B8E4709C64736F6C634300060600 CALLER ",
+      "sourceMap": "350:18983:10:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1593:10;:18;1607:4;1593:18;;1586:26;;;;350:18983;;12:1:-1;9;2:12;5652:653:10;;5:9:-1;2:2;;;27:1;24;17:12;2:2;5652:653:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;5652:653:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;18294:254;;5:9:-1;2:2;;;27:1;24;17:12;2:2;18294:254:10;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;18294:254:10;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;12703:845;;5:9:-1;2:2;;;27:1;24;17:12;2:2;12703:845:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;12703:845:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;12703:845:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;12703:845:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;12703:845:10;;-1:-1:-1;12703:845:10;-1:-1:-1;12703:845:10;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8:100:-1;33:3;30:1;27:10;8:100;;;90:11;;;84:18;71:11;;;64:39;52:2;45:10;8:100;;;12:14;12703:845:10;;;;;;;;;;;;;;;;;19075:256;;5:9:-1;2:2;;;27:1;24;17:12;2:2;19075:256:10;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;19075:256:10;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;19075:256:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;19075:256:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;19075:256:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16;;74:27;;;;-1:-1;19075:256:10;;-1:-1:-1;19075:256:10;;-1:-1:-1;;;;;19075:256:10:i;6310:663::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;6310:663:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;6310:663:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;9934:627::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;9934:627:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;9934:627:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;9934:627:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;9934:627:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;9934:627:10;;-1:-1:-1;9934:627:10;-1:-1:-1;9934:627:10;;;;;;;;;:::i;11875:823::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;11875:823:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;11875:823:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;11875:823:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;11875:823:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;11875:823:10;;-1:-1:-1;11875:823:10;-1:-1:-1;11875:823:10;;;;;;;;;:::i;8395:703::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;8395:703:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;8395:703:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;15703:698::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;15703:698:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;15703:698:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;15703:698:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;15703:698:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;15703:698:10;;-1:-1:-1;15703:698:10;-1:-1:-1;15703:698:10;;;;;;;;;:::i;17239:822::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;17239:822:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;17239:822:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;17239:822:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;17239:822:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;17239:822:10;;-1:-1:-1;17239:822:10;-1:-1:-1;17239:822:10;;;;;;;;;:::i;11176:694::-;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;11176:694:10;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;11176:694:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;11176:694:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;11176:694:10;;-1:-1:-1;11176:694:10;-1:-1:-1;11176:694:10;;;;;;;;;:::i;18554:253::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;18554:253:10;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;18554:253:10;;;;;;;;;;;;:::i;10566:605::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;10566:605:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;10566:605:10;;;;;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;10566:605:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;10566:605:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;10566:605:10;;-1:-1:-1;10566:605:10;-1:-1:-1;10566:605:10;;;;;;;;;:::i;482:38::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;482:38:10;;;:::i;:::-;;;;;;;;;;;;;;;;;;;18102:186;;5:9:-1;2:2;;;27:1;24;17:12;2:2;18102:186:10;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;18102:186:10;;;;;;;;;;;;:::i;7710:680::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;7710:680:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;7710:680:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;16406:828::-;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;16406:828:10;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;16406:828:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;16406:828:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;16406:828:10;;-1:-1:-1;16406:828:10;-1:-1:-1;16406:828:10;;;;;;;;;:::i;4798:849::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;4798:849:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;4798:849:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;435:41::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;435:41:10;;;:::i;526:29::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;526:29:10;;;:::i;18813:256::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;18813:256:10;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;18813:256:10;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;18813:256:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;18813:256:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;18813:256:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16;;74:27;;;;-1:-1;18813:256:10;;-1:-1:-1;18813:256:10;;-1:-1:-1;;;;;18813:256:10:i;6978:656::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;6978:656:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;6978:656:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;3079:723::-;;5:9:-1;2:2;;;27:1;24;17:12;2:2;3079:723:10;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;3079:723:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;3807:951;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;-1:-1;3807:951:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;13553:805::-;;;;;;15:3:-1;10;7:12;4:2;;;32:1;29;22:12;4:2;13553:805:10;;;;;;;;;;;;;;27:11:-1;11:28;;8:2;;;52:1;49;42:12;8:2;13553:805:10;;41:9:-1;34:4;18:14;14:25;11:40;8:2;;;64:1;61;54:12;8:2;13553:805:10;;;;;;101:9:-1;95:2;81:12;77:21;67:8;63:36;60:51;39:11;25:12;22:29;11:108;8:2;;;132:1;129;122:12;8:2;13553:805:10;;-1:-1:-1;13553:805:10;-1:-1:-1;13553:805:10;;;;;;;;;:::i;5652:653::-;5882:16;5900:14;5863:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5953:188:::1;5982:5;6001:4;6019:9;6042:14;6070:12;6104:4;6123:8;5953:15;:188::i;:::-;5926:215:::0;;-1:-1:-1;5926:215:10;-1:-1:-1;6151:51:10::1;6179:5:::0;6186:2;5926:215;6151:27:::1;:51::i;:::-;6218:4;6212:20;;;6233:9;6212:31;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;6212:31:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;6212:31:10;;;;6253:45;6284:2;6288:9;6253:30;:45::i;:::-;5652:653:::0;;;;;;;;;;:::o;18294:254::-;18442:14;18479:62;18509:8;18519:9;18530:10;18479:29;:62::i;:::-;18472:69;18294:254;-1:-1:-1;;;;18294:254:10:o;12703:845::-;12912:21;12885:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;12957:29:::1;12982:4;12957:29;:4:::0;;12962:15;;;12957:21;;::::1;;;;;;;;;;;;;:29;;;12949:71;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;13040:66;13071:7;13080:8;13090:4;;13040:66;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;13095:10:10::1;::::0;-1:-1:-1;13095:8:10::1;::::0;-1:-1:-1;;13095:10:10:i:1;:::-;13040:30;:66::i;:::-;13030:76;;13155:12;13124:7;13149:1;13132:7;:14;:18;13124:27;;;;;;;;;;;;;;:43;;13116:99;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;13225:139;13270:4;;13275:1;13270:7;;;;;;;;;;;;;;;13279:10;13291:51;13316:7;13325:4;;13330:1;13325:7;;;;;;;;;;;;;;;13334:4;;13339:1;13334:7;;;;;;;;;;;;;;;13291:24;:51::i;:::-;13344:7;13352:1;13344:10;;;;;;;;;;;;;;13225:31;:139::i;:::-;13374:35;13380:7;13389:4;;13374:35;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;13403:4:10::1;::::0;-1:-1:-1;13374:5:10::1;::::0;-1:-1:-1;;13374:35:10:i:1;:::-;13425:4;13419:20;;;13440:7;13465:1;13448:7;:14;:18;13440:27;;;;;;;;;;;;;;13419:49;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;13419:49:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;13419:49:10;;;;13478:63;13509:2;13513:7;13538:1;13521:7;:14;:18;13513:27;;;;;;;;;;;;;;13478:30;:63::i;:::-;12703:845:::0;;;;;;;;;:::o;19075:256::-;19214:21;19258:66;19288:7;19297:9;19308:4;19313:10;:8;:10::i;:::-;19258:29;:66::i;:::-;19251:73;;19075:256;;;;;:::o;6310:663::-;6607:12;6621;6645;6660:49;6685:7;6694:6;6702;6660:24;:49::i;:::-;6645:64;;6719:10;6732;:33;;6756:9;6732:33;;;6750:2;6732:33;6775:80;;;;;;6803:10;6775:80;;;;6823:4;6775:80;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6719:46;;-1:-1:-1;6775:27:10;;;;;;:80;;;;;-1:-1:-1;;6775:80:10;;;;;;;;-1:-1:-1;6775:27:10;:80;;;2:2:-1;;;;27:1;24;17:12;2:2;6775:80:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;6775:80:10;;;;6886;6902:6;6910;6918:9;6929:10;6941;6953:2;6957:8;6886:15;:80::i;:::-;6865:101;;;;;;;;6310:663;;;;;;;;;;;;;;;;:::o;9934:627::-;10152:21;10133:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;10195:67:::1;10226:7;10235:8;10245:4;;10195:67;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;10251:10:10::1;::::0;-1:-1:-1;10251:8:10::1;::::0;-1:-1:-1;;10251:10:10:i:1;10195:67::-;10185:77;;10311:12;10280:7;10305:1;10288:7;:14;:18;10280:27;;;;;;;;;;;;;;:43;;10272:99;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;10381:139;10426:4;;10431:1;10426:7;;;;;;10381:139;10530:24;10536:7;10545:4;;10530:24;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;10551:2:10;;-1:-1:-1;10530:5:10::1;::::0;-1:-1:-1;;10530:24:10:i:1;11875:823::-:0;12084:21;12057:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;12129:29:::1;12154:4;12129:29;:4:::0;;12134:15;;;12129:21;;::::1;;;;;;;;;;;;;:29;;;12121:71;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;12212:66;12242:7;12251:9;12262:4;;12212:66;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;12267:10:10::1;::::0;-1:-1:-1;12267:8:10::1;::::0;-1:-1:-1;;12267:10:10:i:1;12212:66::-;12202:76;;12310:11;12296:7;12304:1;12296:10;;;;;;;;;;;;;;:25;;12288:77;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8395:703:::0;8705:14;8731:12;8746:46;8771:7;8780:5;8787:4;8746:24;:46::i;:::-;8731:61;;8802:10;8815;:33;;8839:9;8815:33;;;8833:2;8815:33;8858:80;;;;;;8886:10;8858:80;;;;8906:4;8858:80;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8802:46;;-1:-1:-1;8858:27:10;;;;;;:80;;;;;-1:-1:-1;;8858:80:10;;;;;;;;-1:-1:-1;8858:27:10;:80;;;2:2:-1;;;;27:1;24;17:12;2:2;8858:80:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;8858:80:10;;;;8960:131;9021:5;9028:9;9039:14;9055:12;9069:2;9073:8;8960:47;:131::i;:::-;8948:143;8395:703;-1:-1:-1;;;;;;;;;;;;;8395:703:10:o;15703:698::-;15931:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;15951:137:::1;15996:4;;16001:1;15996:7;;;;;;;;;;;;;;;16005:10;16017:51;16042:7;16051:4;;16056:1;16051:7;;;;;;;;;;;;;;;16060:4;;16065:1;16060:7;;;;;;16017:51;16070:8;15951:31;:137::i;:::-;16098:18;16126:4:::0;;16131:15;;;16126:21;;::::1;;;;;;;;;;;;;16119:39;;;16159:2;16119:43;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;16119:43:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;16119:43:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;16119:43:10;16172:44:::1;::::0;;16119:43:::1;16172:44:::0;;::::1;::::0;;;;;;;;;;;16119:43;;-1:-1:-1;16172:44:10::1;::::0;;;16207:4;;;;;;16172:44;::::1;::::0;16207:4;;16172:44;16207:4;16172:44;1:33:-1::1;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;16213:2:10;;-1:-1:-1;16172:34:10::1;::::0;-1:-1:-1;;16172:44:10:i:1;:::-;16313:12:::0;16247:62:::1;16295:13:::0;16254:4;;16259:15;;;16254:21;;::::1;;;;;;;;;;;;;16247:39;;;16287:2;16247:43;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;16247:43:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;16247:43:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;16247:43:10;;:62:::1;:47;:62;:::i;:::-;:78;;16226:168;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;677:1;15703:698:::0;;;;;;;:::o;17239:822::-;17496:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;17528:29:::1;17553:4;17528:29;:4:::0;;17533:15;;;17528:21;;::::1;;;;;;;;;;;;;:29;;;17520:71;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;17601:137;17646:4;;17651:1;17646:7;;;;;;17601:137;17748:55;17783:4;;17748:55;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;17797:4:10::1;::::0;-1:-1:-1;17748:34:10::1;::::0;-1:-1:-1;;17748:55:10:i:1;:::-;17830:37;::::0;;;;;17861:4:::1;17830:37;::::0;::::1;::::0;;;17813:14:::1;::::0;17830:22:::1;17837:4;17830:22;::::0;::::1;::::0;:37;;;;;::::1;::::0;;;;;;;;;:22;:37;::::1;;2:2:-1::0;::::1;;;27:1;24::::0;17:12:::1;2:2;17830:37:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;17830:37:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;17830:37:10;;-1:-1:-1;17885:25:10;;::::1;;17877:81;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;17974:4;17968:20;;;17989:9;17968:31;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;17968:31:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;17968:31:10;;;;18009:45;18040:2;18044:9;18009:30;:45::i;11176:694::-:0;11386:21;11359:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;11442:4:::1;11431:15;;:4;;11436:1;11431:7;;;;;;;;;;;;;;;:15;;;11423:57;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;11500:67;11531:7;11540:9;11551:4;;11500:67;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;11556:10:10::1;::::0;-1:-1:-1;11556:8:10::1;::::0;-1:-1:-1;;11556:10:10:i:1;11500:67::-;11490:77;;11616:12;11585:7;11610:1;11593:7;:14;:18;11585:27;;;;;;;;;;;;;;:43;;11577:99;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;11692:4;11686:19;;;11713:7;11721:1;11713:10;;;;;;;;;;;;;;11686:40;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;11686:40:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;11686:40:10;;;;;11749:4;11743:20;;;11764:51;11789:7;11798:4;;11803:1;11798:7;;;;;;11764:51;11817:7;11825:1;11817:10;;;;;;;;;;;;;;11743:85;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;11743:85:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;11743:85:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;11743:85:10;11736:93:::1;;;;11839:24;11845:7;11854:4;;11839:24;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;11860:2:10;;-1:-1:-1;11839:5:10::1;::::0;-1:-1:-1;;11839:24:10:i:1;:::-;11176:694:::0;;;;;;;;:::o;18554:253::-;18702:13;18738:62;18767:9;18778;18789:10;18738:28;:62::i;10566:605::-;10784:21;10765:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;10827:67:::1;10857:7;10866:9;10877:4;;10827:67;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;10883:10:10::1;::::0;-1:-1:-1;10883:8:10::1;::::0;-1:-1:-1;;10883:10:10:i:1;10827:67::-;10817:77;;10926:11;10912:7;10920:1;10912:10;;;;;;;;;;;;;;:25;;10904:77;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;482:38:::0;;;:::o;18102:186::-;18199:12;18230:51;18253:7;18262:8;18272;18230:22;:51::i;7710:680::-;7969:14;7950:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8011:188:::1;8040:5;8059:4;8077:9;8100:14;8128:12;8162:4;8181:8;8011:15;:188::i;:::-;8248:38;::::0;;;;;8280:4:::1;8248:38;::::0;::::1;::::0;;;7995:204;;-1:-1:-1;8209:78:10::1;::::0;-1:-1:-1;8237:5:10;;8244:2;;8248:23:::1;::::0;::::1;::::0;::::1;::::0;:38;;;;;::::1;::::0;;;;;;;;;:23;:38;::::1;;2:2:-1::0;::::1;;;27:1;24::::0;17:12:::1;2:2;8248:38:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;8248:38:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;8248:38:10;8209:27:::1;:78::i;:::-;8303:4;8297:20;;;8318:9;8297:31;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;8297:31:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;8297:31:10;;;;8338:45;8369:2;8373:9;8338:30;:45::i;16406:828::-:0;16656:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;16699:4:::1;16688:15;;:4;;16693:1;16688:7;;;;;;;;;;;;;;;:15;;;16680:57;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;16747:13;16763:9;16747:25;;16788:4;16782:19;;;16809:8;16782:38;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;16782:38:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;16782:38:10;;;;;16843:4;16837:20;;;16858:51;16883:7;16892:4;;16897:1;16892:7;;;;;;16858:51;16911:8;16837:83;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;16837:83:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;16837:83:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;16837:83:10;16830:91:::1;;;;16931:18;16959:4:::0;;16964:15;;;16959:21;;::::1;;;;;;;;;;;;;16952:39;;;16992:2;16952:43;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;16952:43:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;16952:43:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;16952:43:10;17005:44:::1;::::0;;16952:43:::1;17005:44:::0;;::::1;::::0;;;;;;;;;;;16952:43;;-1:-1:-1;17005:44:10::1;::::0;;;17040:4;;;;;;17005:44;::::1;::::0;17040:4;;17005:44;17040:4;17005:44;1:33:-1::1;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;17046:2:10;;-1:-1:-1;17005:34:10::1;::::0;-1:-1:-1;;17005:44:10:i:1;:::-;17146:12:::0;17080:62:::1;17128:13:::0;17087:4;;17092:15;;;17087:21;;::::1;;;;;;;;;;;;;17080:39;;;17120:2;17080:43;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;4798:849:10::0;5044:12;5058;5025:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5082:12:::1;5097:49;5122:7;5131:6;5139;5097:24;:49::i;:::-;5156:62;::::0;;;;;5190:10:::1;5156:62;::::0;::::1;::::0;:33:::1;::::0;::::1;:62:::0;;;;;;;;;;;;;;5082:64;;-1:-1:-1;5156:33:10;;::::1;::::0;:62;;;;;::::1;::::0;;;;;;;;;-1:-1:-1;5156:33:10;:62;::::1;;2:2:-1::0;::::1;;;27:1;24::::0;17:12:::1;2:2;5156:62:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;5156:62:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;;5285:29:10::1;::::0;;;;;:25:::1;:29:::0;;::::1;;::::0;::::1;::::0;;;5255:12:::1;::::0;;;5285:25;;::::1;::::0;::::1;::::0;:29;;;;;;;;;;;5255:12;5285:25;:29;::::1;;2:2:-1::0;::::1;;;27:1;24::::0;17:12:::1;2:2;5285:29:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;5285:29:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;5285:29:10;;::::1;::::0;;::::1;::::0;;;-1:-1:-1;5285:29:10;-1:-1:-1;5325:14:10::1;5344:43;5372:6:::0;5380;5344:27:::1;:43::i;:::-;5324:63;;;5428:6;5418:16;;:6;:16;;;:58;;5459:7;5468;5418:58;;;5438:7;5447;5418:58;5397:79:::0;;-1:-1:-1;5397:79:10;-1:-1:-1;5494:21:10;;::::1;;5486:72;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5587:10;5576:7;:21;;5568:72;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;677:1;;;;4798:849:::0;;;;;;;;;;;:::o;435:41::-;;;:::o;526:29::-;;;;;;:::o;18813:256::-;18952:21;18996:66;19027:7;19036:8;19046:4;19051:10;:8;:10::i;6978:656::-;7259:16;7277:14;7303:12;7318:46;7343:7;7352:5;7359:4;7318:24;:46::i;:::-;7303:61;;7374:10;7387;:33;;7411:9;7387:33;;;7405:2;7387:33;7430:80;;;;;;7458:10;7430:80;;;;7478:4;7430:80;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;7374:46;;-1:-1:-1;7430:27:10;;;;;;:80;;;;;-1:-1:-1;;7430:80:10;;;;;;;;-1:-1:-1;7430:27:10;:80;;;2:2:-1;;;;27:1;24;17:12;2:2;7430:80:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;7430:80:10;;;;7547;7566:5;7573:9;7584:14;7600:12;7614:2;7618:8;7547:18;:80::i;:::-;7520:107;;;;-1:-1:-1;6978:656:10;-1:-1:-1;;;;;;;;;;;;;6978:656:10:o;3079:723::-;3358:12;3372;3386:14;3339:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3433:85:::1;3447:6;3455;3463:14;3479;3495:10;3507;3433:13;:85::i;:::-;3412:106:::0;;-1:-1:-1;3412:106:10;-1:-1:-1;3528:12:10::1;3543:49;3568:7;3577:6:::0;3585;3543:24:::1;:49::i;:::-;3528:64;;3602:66;3634:6;3642:10;3654:4;3660:7;3602:31;:66::i;:::-;3678;3710:6;3718:10;3730:4;3736:7;3678:31;:66::i;:::-;3781:4;3766:25;;;3792:2;3766:29;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;3766:29:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;3766:29:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;3766:29:10;3079:723;;;;-1:-1:-1;3766:29:10;;-1:-1:-1;3079:723:10;;-1:-1:-1;;;;;;;;;3079:723:10:o;3807:951::-;4053:16;4071:14;4087;4034:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4140:169:::1;4167:5;4186:4;4204:18;4236:9;4259:14;4287:12;4140:13;:169::i;:::-;4113:196:::0;;-1:-1:-1;4113:196:10;-1:-1:-1;4319:12:10::1;4334:46;4359:7;4368:5:::0;4375:4:::1;4334:24;:46::i;:::-;4319:61;;4390:69;4422:5;4429:10;4441:4;4447:11;4390:31;:69::i;:::-;4475:4;4469:19;;;4496:9;4469:39;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;4469:39:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;4469:39:10;;;;;4531:4;4525:20;;;4546:4;4552:9;4525:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;4525:37:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;4525:37:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;4525:37:10;4518:45:::1;;;;4600:4;4585:25;;;4611:2;4585:29;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;4585:29:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;4585:29:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;4585:29:10;;-1:-1:-1;4663:9:10::1;:21:::0;-1:-1:-1;4659:92:10::1;;;4686:65;4717:10;4741:9;4729;:21;4686:30;:65::i;:::-;677:1;3807:951:::0;;;;;;;;;;;:::o;13553:805::-;13760:21;13733:8;623:15;611:8;:27;;603:64;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;13816:4:::1;13805:15;;:4;;13810:1;13805:7;;;;;;;;;;;;;;;:15;;;13797:57;;;::::0;;::::1;::::0;;::::1;;::::0;::::1;::::0;::::1;::::0;;;;::::1;::::0;;;;;;;;;;;;;::::1;;13874:66;13904:7;13913:9;13924:4;;13874:66;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;13929:10:10::1;::::0;-1:-1:-1;13929:8:10::1;::::0;-1:-1:-1;;13929:10:10:i:1;13874:66::-;13864:76;;13972:9;13958:7;13966:1;13958:10;;;;;;;;;;;;;;:23;;13950:75;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;14041:4;14035:19;;;14062:7;14070:1;14062:10;;;;;;;;;;;;;;14035:40;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;14035:40:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;14035:40:10;;;;;14098:4;14092:20;;;14113:51;14138:7;14147:4;;14152:1;14147:7;;;;;;14113:51;14166:7;14174:1;14166:10;;;;;;;;;;;;;;14092:85;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24::::0;17:12:::1;2:2;14092:85:10;;;;8:9:-1;5:2;;;45:16;42:1;39::::0;24:38:::1;77:16;74:1;67:27;5:2;14092:85:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28::::0;21:12:::1;4:2;-1:-1:::0;14092:85:10;14085:93:::1;;;;14188:24;14194:7;14203:4;;14188:24;;;;;;;;;;;;;;;;;;;;;;;;;;;30:3:-1;22:6;14;1:33;99:1;81:16:::0;::::1;74:27:::0;;;;-1:-1;14209:2:10;;-1:-1:-1;14188:5:10::1;::::0;-1:-1:-1;;14188:24:10:i:1;:::-;14273:7;14281:1;14273:10;;;;;;;;;;;;;;14261:9;:22;14257:94;;;14285:66;14316:10;14340:7;14348:1;14340:10;;;;;;;;;;;;;;14328:9;:22;14285:30;:66::i;652:438:4:-:0;878:45;;;867:10;878:45;;;;;;;;;;;;;;;;26:21:-1;;;22:32;;;6:49;;878:45:4;;;;;;;25:18:-1;;61:17;;96:58;182:15;878:45:4;179:29:-1;160:49;;867:57:4;;;;832:12;;846:17;;867:10;;;;878:45;867:57;;;25:18:-1;867:57:4;;25:18:-1;36:153;66:2;61:3;58:11;36:153;;176:10;;164:23;;139:12;;;;;98:2;89:12;;;;114;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;867:57:4;;;;;;;;;;;;;;;;;;;;;;;;12:1:-1;19;14:27;;;;67:4;61:11;56:16;;134:4;130:9;123:4;105:16;101:27;97:43;94:1;90:51;84:4;77:65;157:16;154:1;147:27;211:16;208:1;201:4;198:1;194:12;179:49;5:228;;14:27;32:4;27:9;;5:228;;831:93:4;;;;955:7;:57;;;;-1:-1:-1;967:11:4;;:16;;:44;;;998:4;987:24;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;987:24:4;967:44;934:149;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;652:438;;;;;:::o;1588:214::-;1700:12;;;1660;1700;;;;;;;;;1678:7;;;;1693:5;;1678:35;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:11;36:153;;176:10;;164:23;;139:12;;;;;98:2;89:12;;;;114;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;1678:35:4;;;;;;;;;;;;;;;;;;;;;;;;;12:1:-1;19;14:27;;;;67:4;61:11;56:16;;134:4;130:9;123:4;105:16;101:27;97:43;94:1;90:51;84:4;77:65;157:16;154:1;147:27;211:16;208:1;201:4;198:1;194:12;179:49;5:228;;14:27;32:4;27:9;;5:228;;1659:54:4;;;1731:7;1723:72;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1588:214;;;:::o;2276:510:24:-;2369:14;2414:1;2403:8;:12;2395:68;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2493:1;2481:9;:13;:31;;;;;2511:1;2498:10;:14;2481:31;2473:84;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2567:20;2590:17;:8;224:3;2590:17;:12;:17;:::i;:::-;2567:40;-1:-1:-1;2617:14:24;2634:31;2567:40;2654:10;2634:31;:19;:31;:::i;:::-;2617:48;-1:-1:-1;2675:16:24;2694:40;2718:15;2694:19;:9;2708:4;2694:19;:13;:19;:::i;:::-;:23;:40;:23;:40;:::i;:::-;2675:59;;2768:11;2756:9;:23;;;;;;;2276:510;-1:-1:-1;;;;;;;2276:510:24:o;1438:105:10:-;1482:4;1521:14;;;1507:10;:28;1505:31;;1438:105::o;5024:532:24:-;5142:21;5198:1;5183:4;:11;:16;;5175:59;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5265:4;:11;5254:23;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;5254:23:24;;;;;;;;;;;;;;;;;;;;;;;29:2:-1;21:6;17:15;125:4;109:14;101:6;88:42;144:17;;-1:-1;5254:23:24;;5244:33;;5300:8;5287:7;5295:1;5287:10;;;;;;;;;;;;;:21;;;;;5323:6;5318:232;5349:1;5335:4;:11;:15;5331:1;:19;5318:232;;;5372:14;5388:15;5407:42;5419:7;5428:4;5433:1;5428:7;;;;;;;;;;;;;;5437:4;5442:1;5446;5442:5;5437:11;;;;;;;;;;;;;;5407;:42::i;:::-;5371:78;;;;5480:59;5493:7;5501:1;5493:10;;;;;;;;;;;;;;5505:9;5516:10;5528;5480:12;:59::i;:::-;5463:7;5471:1;5475;5471:5;5463:14;;;;;;;;;;;;;;;;;:76;-1:-1:-1;;5352:3:24;;5318:232;;;;5024:532;;;;;;:::o;818:470::-;907:12;932:14;948;966:26;977:6;985;966:10;:26::i;:::-;1126:32;;;;;;;;;;;;;;;;;;;;;;;;;;;;;22::-1;26:21;;;22:32;6:49;;1126:32:24;;;;;1116:43;;;;;;1032:246;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;26:21:-1;;;22:32;;;6:49;;1032:246:24;;;;;;;1022:257;;;;;;;;;818:470;-1:-1:-1;;;;;818:470:24:o;1096:486:4:-;1360:51;;;1349:10;1360:51;;;;;;;;;;;;;;;;;;;;;;;26:21:-1;;;22:32;;;6:49;;1360:51:4;;;;;;;25:18:-1;;61:17;;96:58;182:15;1360:51:4;179:29:-1;160:49;;1349:63:4;;;;1314:12;;1328:17;;1349:10;;;;1360:51;1349:63;;;25:18:-1;1349:63:4;;25:18:-1;36:153;66:2;61:3;58:11;36:153;;176:10;;164:23;;139:12;;;;;98:2;89:12;;;;114;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;1349:63:4;;;;;;;;;;;;;;;;;;;;;;;;12:1:-1;19;14:27;;;;67:4;61:11;56:16;;134:4;130:9;123:4;105:16;101:27;97:43;94:1;90:51;84:4;77:65;157:16;154:1;147:27;211:16;208:1;201:4;198:1;194:12;179:49;5:228;;14:27;32:4;27:9;;5:228;;1313:99:4;;;;1443:7;:57;;;;-1:-1:-1;1455:11:4;;:16;;:44;;;1486:4;1475:24;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;1475:24:4;1455:44;1422:153;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1096:486;;;;;;:::o;9205:724:10:-;9311:6;9306:617;9337:1;9323:4;:11;:15;9319:1;:19;9306:617;;;9360:13;9375:14;9394:4;9399:1;9394:7;;;;;;;;;;;;;;9403:4;9408:1;9412;9408:5;9403:11;;;;;;;;;;;;;;9359:56;;;;9430:14;9449:42;9477:5;9484:6;9449:27;:42::i;:::-;9429:62;;;9505:14;9522:7;9530:1;9534;9530:5;9522:14;;;;;;;;;;;;;;9505:31;;9551:15;9568;9596:6;9587:15;;:5;:15;;;:61;;9629:9;9645:1;9587:61;;;9611:1;9615:9;9587:61;9550:98;;;;9662:10;9693:1;9679:4;:11;:15;9675:1;:19;:82;;9754:3;9675:82;;;9697:54;9722:7;9731:6;9739:4;9744:1;9748;9744:5;9739:11;;;;;;;;;;;;;;9697:24;:54::i;:::-;9662:95;;9786:48;9811:7;9820:5;9827:6;9786:24;:48::i;:::-;9771:69;;;9858:10;9870;9882:2;9896:1;9886:12;;;;;;;;;;;;;;;;;;;;;;;;;21:6:-1;;108:14;9886:12:10;87:42:-1;143:17;;-1:-1;9886:12:10;;9771:141;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;90:11;;;84:18;71:11;;;64:39;52:2;45:10;8:100;;;12:14;9771:141:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;9771:141:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;-1:-1;;9340:3:10;;;;;-1:-1:-1;9306:617:10;;-1:-1:-1;;;;;;;;9306:617:10;;;9205:724;;;:::o;5634:553:24:-;5752:21;5808:1;5793:4;:11;:16;;5785:59;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5875:4;:11;5864:23;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;5864:23:24;;;;;;;;;;;;;;;;;;;;;;;29:2:-1;21:6;17:15;125:4;109:14;101:6;88:42;144:17;;-1:-1;5864:23:24;;5854:33;;5927:9;5897:7;5922:1;5905:7;:14;:18;5897:27;;;;;;;;;;;;;;;;;:39;5960:11;;:15;;5946:235;5977:5;;5946:235;;6004:14;6020:15;6039:42;6051:7;6060:4;6069:1;6065;:5;6060:11;;;;;;;;;;;;;;6073:4;6078:1;6073:7;;;;;;;6039:42;6003:78;;;;6112:58;6124:7;6132:1;6124:10;;;;;;;;;;;;;;6136:9;6147:10;6159;6112:11;:58::i;:::-;6095:7;6107:1;6103;:5;6095:14;;;;;;;;;;;;;;;;;:75;-1:-1:-1;;5984:3:24;;5946:235;;14501:1197:10;14613:6;14608:1084;14639:1;14625:4;:11;:15;14621:1;:19;14608:1084;;;14662:13;14677:14;14696:4;14701:1;14696:7;;;;;;;;;;;;;;14705:4;14710:1;14714;14710:5;14705:11;;;;;;;;;;;;;;14661:56;;;;14732:14;14751:42;14779:5;14786:6;14751:27;:42::i;:::-;14731:62;;;14807:19;14844:48;14869:7;14878:5;14885:6;14844:24;:48::i;:::-;14807:86;;14907:16;14937:17;15023:13;15038;15056:4;:16;;;:18;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;15056:18:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;15056:18:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;15056:18:10;;;;;;;15022:52;;;;;-1:-1:-1;15022:52:10;;-1:-1:-1;15089:17:10;;15130:15;;;;;;;;:61;;15172:8;15182;15130:61;;;15149:8;15159;15130:61;15088:103;;;;15219:56;15262:12;15226:5;15219:23;;;15251:4;15219:38;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24;17:12;15219:56:10;15205:70;;15304:71;15334:11;15347:12;15361:13;15304:29;:71::i;:::-;15289:86;;14608:1084;;;;15404:15;15421;15449:6;15440:15;;:5;:15;;;:67;;15485:12;15504:1;15440:67;;;15464:1;15468:12;15440:67;15403:104;;;;15521:10;15552:1;15538:4;:11;:15;15534:1;:19;:82;;15613:3;15534:82;;;15556:54;15581:7;15590:6;15598:4;15603:1;15607;15603:5;15598:11;;;;;;;15556:54;15668:12;;;15678:1;15668:12;;;;;;;;;;15630:51;;;;;;;;;;;;;;;:9;:51;;;;;;;;;;;;;;;;;;;;;;15521:95;;-1:-1:-1;15630:9:10;;;;;;15640:10;;15652;;15521:95;;15668:12;;15630:51;;;;;;;;15668:12;;15630:51;;;;15668:12;;8:100:-1;33:3;30:1;27:10;8:100;;;90:11;;;84:18;71:11;;;64:39;52:2;45:10;8:100;;;12:14;15630:51:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;15630:51:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;-1:-1;;14642:3:10;;;;;-1:-1:-1;14608:1084:10;;-1:-1:-1;;;;;;;;;;14608:1084:10;286:127:23;369:5;;;364:16;;;;356:50;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3715:466:24;3808:13;3853:1;3841:9;:13;3833:70;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3933:1;3921:9;:13;:31;;;;;3951:1;3938:10;:14;3921:31;3913:84;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4007:14;4024:34;4053:4;4024:24;:9;4038;4024:24;:13;:24;:::i;:::-;:28;:34;:28;:34;:::i;:::-;4007:51;-1:-1:-1;4068:16:24;4087:34;224:3;4087:25;:10;4102:9;4087:25;:14;:25;:::i;:34::-;4068:53;;4142:32;4172:1;4155:11;4143:9;:23;;;;;;;4142:32;:29;:32;:::i;:::-;4131:43;3715:466;-1:-1:-1;;;;;;3715:466:24:o;1840:317::-;1922:12;1964:1;1954:7;:11;1946:61;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2036:1;2025:8;:12;:28;;;;;2052:1;2041:8;:12;2025:28;2017:81;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2142:8;2118:21;:7;2130:8;2118:21;:11;:21;:::i;:::-;:32;;;;;;;1840:317;-1:-1:-1;;;;1840:317:24:o;384:345::-;459:14;475;519:6;509:16;;:6;:16;;;;501:66;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;605:6;596:15;;:6;:15;;;:53;;634:6;642;596:53;;;615:6;623;596:53;577:72;;-1:-1:-1;577:72:24;-1:-1:-1;667:20:24;;;659:63;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;384:345;;;;;:::o;1711:1363:10:-;2015:50;;;;;;:64;:50;;;;;;;;;;;;;;;;1922:12;;;;;;2033:7;2015:34;;;;;;:50;;;;;;;;;;;;;;;:34;:50;;;2:2:-1;;;;27:1;24;17:12;2:2;2015:50:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2015:50:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;2015:50:10;:64;;;2011:148;;;2095:53;;;;;;:37;:53;;;;;;;;;;;;;;;;2113:7;2095:37;;;;;;:53;;;;;;;;;;;;;;;-1:-1:-1;2095:37:10;:53;;;2:2:-1;;;;27:1;24;17:12;2:2;2095:53:10;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2095:53:10;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;;2011:148:10;2169:13;2184;2201:53;2230:7;2239:6;2247;2201:28;:53::i;:::-;2168:86;;;;2268:8;2280:1;2268:13;:30;;;;-1:-1:-1;2285:13:10;;2268:30;2264:804;;;2336:14;;-1:-1:-1;2352:14:10;;-1:-1:-1;2264:804:10;;;2398:19;2420:58;2443:14;2459:8;2469;2420:22;:58::i;:::-;2398:80;;2514:14;2496;:32;2492:566;;2574:10;2556:14;:28;;2548:79;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2667:14;;-1:-1:-1;2683:14:10;-1:-1:-1;2683:14:10;2492:566;;;2737:19;2759:58;2782:14;2798:8;2808;2759:22;:58::i;:::-;2737:80;;2860:14;2842;:32;;2835:40;;;;2919:10;2901:14;:28;;2893:79;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3012:14;-1:-1:-1;3028:14:10;;-1:-1:-1;2492:566:10;2264:804;;1711:1363;;;;;;;;;;;:::o;419:140:23:-;471:6;497;;;:30;;-1:-1:-1;;512:5:23;;;526:1;521;512:5;521:1;507:15;;;;;:20;497:30;489:63;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;154:126;237:5;;;232:16;;;;224:49;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1343:387:24;1436:13;1451;1477:14;1496:26;1507:6;1515;1496:10;:26::i;:::-;1476:46;;;1533:13;1548;1581:32;1589:7;1598:6;1606;1581:7;:32::i;:::-;1566:60;;;:62;;;;;;;;;;;;;;;;;;;;;;5:9:-1;2:2;;;27:1;24;17:12;2:2;1566:62:24;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;1566:62:24;;;;;;;15:2:-1;10:3;7:11;4:2;;;31:1;28;21:12;4:2;-1:-1;1566:62:24;;;;;;;1532:96;;;;;-1:-1:-1;1532:96:24;;-1:-1:-1;1661:16:24;;;;;;;;:62;;1704:8;1714;1661:62;;;1681:8;1691;1661:62;1638:85;;;;-1:-1:-1;1343:387:24;-1:-1:-1;;;;;;;1343:387:24:o;2985:612::-;3095:14;3125:10;3121:93;;;3158:45;3171:8;3181:9;3192:10;3158:12;:45::i;:::-;3151:52;;;;3121:93;3243:1;3232:8;:12;3224:68;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3322:1;3310:9;:13;:31;;;;;3340:1;3327:10;:14;3310:31;3302:84;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3396:20;3419;:8;273:4;3419:20;:12;:20;:::i;:::-;3396:43;-1:-1:-1;3449:14:24;3466:31;3396:43;3486:10;3466:31;:19;:31;:::i;:::-;3449:48;-1:-1:-1;3507:16:24;3526:19;:9;3540:4;3526:19;:13;:19;:::i;:::-;3507:38;;3579:11;3567:9;:23;;;;;;;2985:612;-1:-1:-1;;;;;;;;2985:612:24:o;4379:566::-;4488:13;4517:10;4513:93;;;4550:45;4562:9;4573;4584:10;4550:11;:45::i;4513:93::-;4636:1;4624:9;:13;4616:70;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4716:1;4704:9;:13;:31;;;;;4734:1;4721:10;:14;4704:31;4696:84;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4790:14;4807:34;4836:4;4807:24;:9;4821;4807:24;:13;:24;:::i;:34::-;4790:51;-1:-1:-1;4851:16:24;4870:22;:10;273:4;4870:22;:14;:22;:::i"
+    }
+  },
+  "metadata": "{\"compiler\":{\"version\":\"0.6.6+commit.6c089d02\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_factory\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_WETH\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_dsSwapContract\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"WETH\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"tokenA\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenB\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountADesired\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountBDesired\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountAMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountBMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"addLiquidity\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountA\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountB\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenDesired\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETHMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"addLiquidityETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountToken\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETH\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"dsSwapContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"factory\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveOut\",\"type\":\"uint256\"}],\"name\":\"getAmountIn\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveOut\",\"type\":\"uint256\"}],\"name\":\"getAmountOut\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"}],\"name\":\"getAmountsIn\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"}],\"name\":\"getAmountsOut\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountA\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveA\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reserveB\",\"type\":\"uint256\"}],\"name\":\"quote\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountB\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"tokenA\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenB\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountAMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountBMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"removeLiquidity\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountA\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountB\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETHMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"removeLiquidityETH\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountToken\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETH\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETHMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"removeLiquidityETHSupportingFeeOnTransferTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountETH\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETHMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"approveMax\",\"type\":\"bool\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"removeLiquidityETHWithPermit\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountToken\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETH\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountTokenMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountETHMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"approveMax\",\"type\":\"bool\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"removeLiquidityETHWithPermitSupportingFeeOnTransferTokens\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountETH\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"tokenA\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"tokenB\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"liquidity\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountAMin\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountBMin\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"approveMax\",\"type\":\"bool\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"removeLiquidityWithPermit\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"amountA\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountB\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapETHForExactTokens\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactETHForTokens\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactETHForTokensSupportingFeeOnTransferTokens\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactTokensForETH\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactTokensForETHSupportingFeeOnTransferTokens\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactTokensForTokens\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountIn\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountOutMin\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapExactTokensForTokensSupportingFeeOnTransferTokens\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMax\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapTokensForExactETH\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountOut\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountInMax\",\"type\":\"uint256\"},{\"internalType\":\"address[]\",\"name\":\"path\",\"type\":\"address[]\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"swapTokensForExactTokens\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"amounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"contracts/UniswapV2Router02.sol\":\"UniswapV2Router02\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":999999},\"remappings\":[]},\"sources\":{\"@uniswap/lib/contracts/libraries/TransferHelper.sol\":{\"keccak256\":\"0xaff99b54915f57e2a4e71b8d15afd4ee425410e5a6f45c07517ae1beb806f8bd\",\"urls\":[\"bzz-raw://15432ec031f4cfa6709921289e198b030a0c5eac75b5a3e0eb64827a2b3b5595\",\"dweb:/ipfs/QmZvR1KuuDvuzXFiADCngTKyMCTy31uhq9U6CazP59B55j\"]},\"@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol\":{\"keccak256\":\"0xe5905c0989cf5a865ed9bb7b9252536ca011c5b744017a82a7d4443b9c00a891\",\"urls\":[\"bzz-raw://5d2a90a0a796491507462a3da18c3f8819721d571572d765a2207c35bf0a0389\",\"dweb:/ipfs/Qmf9ACYiT3qzjgsYuhm866FBdiBpRMXAPpQhSFbgqcyhHt\"]},\"@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol\":{\"keccak256\":\"0x7c9bc70e5996c763e02ff38905282bc24fb242b0ef2519a003b36824fc524a4b\",\"urls\":[\"bzz-raw://85d5ad2dd23ee127f40907a12865a1e8cb5828814f6f2480285e1827dd72dedf\",\"dweb:/ipfs/QmayKQWJgWmr46DqWseADyUanmqxh662hPNdAkdHRjiQQH\"]},\"contracts/UniswapV2Router02.sol\":{\"keccak256\":\"0x296bcd389e5a7b161064656ffd79ca3622c56d74122ccd5671191a3e3440f203\",\"urls\":[\"bzz-raw://6dd30d7582bfc6b9103cb6a70fba4cfc3317a64a45ea2ce2c134dea8515a2654\",\"dweb:/ipfs/QmTJEVLLKFntGNmTxNG5GL56FpknpqFAkSgiRkYoYTCnFu\"]},\"contracts/interfaces/IERC20.sol\":{\"keccak256\":\"0x61db17aebc5d812c7002d15c1da954065e56abe49d64b14c034abe5604d70eb3\",\"urls\":[\"bzz-raw://b006685e753f9120469f10b09c159f222d4cb8b507a6c1f0c14ed50c883ebe66\",\"dweb:/ipfs/QmSyY7iTugbczPwfGK67etiyPULenYGzzRYbt8aabwwkUb\"]},\"contracts/interfaces/IUniswapV2Router01.sol\":{\"keccak256\":\"0x8a3c5c449d4b7cd76513ed6995f4b86e4a86f222c770f8442f5fc128ce29b4d2\",\"urls\":[\"bzz-raw://1df63ca373dafae3bd0ee7fe70f890a1dc7c45ed869c01de68413e0e97ff9deb\",\"dweb:/ipfs/QmefJgEYGUL8KX7kQKYTrDweF8GB7yjy3nw5Bmqzryg7PG\"]},\"contracts/interfaces/IUniswapV2Router02.sol\":{\"keccak256\":\"0x744e30c133bd0f7ca9e7163433cf6d72f45c6bb1508c2c9c02f1a6db796ae59d\",\"urls\":[\"bzz-raw://9bf2f4454ad63d4cff03a0630e787d9e8a9deed80aec89682cd8ad6379d9ef8c\",\"dweb:/ipfs/Qme51hQNR2wpax7ooUadhtqLtXm8ffeVVYyubLkTT4wMCG\"]},\"contracts/interfaces/IWETH.sol\":{\"keccak256\":\"0xfc10758fd8dba790c39468dccd358cb7cef06ae7c4781832cc7aa76f91f167e6\",\"urls\":[\"bzz-raw://dc22493dea6c60d47835eeba53726f8a6f76f4fcd798d40e54608a1380515d49\",\"dweb:/ipfs/QmS1QVcBRH4TELYNE7XCfjSVQEWFupyaNLKmMkKH7iPjrm\"]},\"contracts/libraries/SafeMath.sol\":{\"keccak256\":\"0x27f0ea82f879b3b01387b583e6d9d0ec858dca3b22b0aad173f8fbda06e761e1\",\"urls\":[\"bzz-raw://0db9cf37793eb7035f0bfced36323d240f0212150009c39a3a108701d9b50b6c\",\"dweb:/ipfs/QmUAdiG9XNcieXkKfiMB49zQqD34FbXFE15csV2KQzwEqg\"]},\"contracts/libraries/UniswapV2Library.sol\":{\"keccak256\":\"0x319aeb86d56822232b35da8f36c6d93a42a4d1a36e25236ff4f3aa3725aa98e4\",\"urls\":[\"bzz-raw://477cb9e314c45a71d9534999c105fb550278ccbf0a0639f44e08266d6f8e7178\",\"dweb:/ipfs/QmTZCKBW6PKQqRF5V7p5YkdwT1w6qXVJk7fFMzoqLKXYrp\"]}},\"version\":1}",
+  "interface": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_factory",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_WETH",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_dsSwapContract",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "WETH",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountADesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenDesired",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "addLiquidityETH",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "dsSwapContract",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "factory",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAmountIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAmountOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getAmountsIn",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        }
+      ],
+      "name": "getAmountsOut",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveB",
+          "type": "uint256"
+        }
+      ],
+      "name": "quote",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidityETH",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityETHWithPermit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountToken",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountTokenMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountETHMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountETH",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenA",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenB",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "liquidity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountAMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountBMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "approveMax",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "removeLiquidityWithPermit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountA",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountB",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapETHForExactTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactETHForTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForETH",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForETHSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutMin",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountInMax",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapTokensForExactETH",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountInMax",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "path",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "swapTokensForExactTokens",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "60c06040523480156200001157600080fd5b5060405162005a4438038062005a44833981810160405260608110156200003757600080fd5b5080516020820151604090920151606082811b6001600160601b03199081166080529084901b1660a052600080546001600160a01b0319166001600160a01b0392831617815591811692169061589f90620001a59039806101b75280610e7d5280610eb85280610ff552806112c15280611727528061190f5280611e575280611fdb52806120ab52806121b2528061236952806123fe52806126b4528061275b528061283052806129355280612a1d5280612a9e528061314c528061348252806134d8528061350c528061358d52806137a7528061395b52806139f05250806110e752806111ee528061139452806113d55280611580528061181952806118ed5280611ada5280612298528061243d52806125e65280612add5280612e2052806130b252806130f7528061312a528061330752806134b6528061388d5280613a2f52806144b952806144fc528061485d5280614a3e5280614fb9528061509a528061511a525061589f6000f3fe60806040526004361061019a5760003560e01c80638803dbee116100e1578063c45a01551161008a578063ded9382a11610064578063ded9382a14610c11578063e8e3370014610c91578063f305d71914610d1e578063fb3bdb4114610d71576101e0565b8063c45a015514610b30578063caa0c28c14610b45578063d06ca61f14610b5a576101e0565b8063af2979eb116100bb578063af2979eb146109d3578063b6f9de9514610a33578063baa2abde14610ac6576101e0565b80638803dbee146108ba578063ad5c46481461095f578063ad615dec1461099d576101e0565b80634a25d94a11610143578063791ac9471161011d578063791ac9471461074c5780637ff36ab5146107f157806385f8c25914610884576101e0565b80634a25d94a146105825780635b0d5984146106275780635c11d795146106a7576101e0565b80631f00ca74116101745780631f00ca741461039b5780632195995c1461045257806338ed1739146104dd576101e0565b806302751cec146101e5578063054d50d41461025e57806318cbafe5146102a6576101e0565b366101e0573373ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016146101de57fe5b005b600080fd5b3480156101f157600080fd5b50610245600480360360c081101561020857600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135610e04565b6040805192835260208301919091528051918290030190f35b34801561026a57600080fd5b506102946004803603606081101561028157600080fd5b5080359060208101359060400135610f57565b60408051918252519081900360200190f35b3480156102b257600080fd5b5061034b600480360360a08110156102c957600080fd5b8135916020810135918101906060810160408201356401000000008111156102f057600080fd5b82018360208201111561030257600080fd5b8035906020019184602083028401116401000000008311171561032457600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135610f6c565b60408051602080825283518183015283519192839290830191858101910280838360005b8381101561038757818101518382015260200161036f565b505050509050019250505060405180910390f35b3480156103a757600080fd5b5061034b600480360360408110156103be57600080fd5b813591908101906040810160208201356401000000008111156103e057600080fd5b8201836020820111156103f257600080fd5b8035906020019184602083028401116401000000008311171561041457600080fd5b91908080602002602001604051908101604052809392919081815260200183836020028082843760009201919091525092955061138d945050505050565b34801561045e57600080fd5b50610245600480360361016081101561047657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c08101359060e081013515159060ff61010082013516906101208101359061014001356113cb565b3480156104e957600080fd5b5061034b600480360360a081101561050057600080fd5b81359160208101359181019060608101604082013564010000000081111561052757600080fd5b82018360208201111561053957600080fd5b8035906020019184602083028401116401000000008311171561055b57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611509565b34801561058e57600080fd5b5061034b600480360360a08110156105a557600080fd5b8135916020810135918101906060810160408201356401000000008111156105cc57600080fd5b8201836020820111156105de57600080fd5b8035906020019184602083028401116401000000008311171561060057600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561169e565b34801561063357600080fd5b50610294600480360361014081101561064b57600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e082013516906101008101359061012001356118e5565b3480156106b357600080fd5b506101de600480360360a08110156106ca57600080fd5b8135916020810135918101906060810160408201356401000000008111156106f157600080fd5b82018360208201111561070357600080fd5b8035906020019184602083028401116401000000008311171561072557600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611a37565b34801561075857600080fd5b506101de600480360360a081101561076f57600080fd5b81359160208101359181019060608101604082013564010000000081111561079657600080fd5b8201836020820111156107a857600080fd5b803590602001918460208302840111640100000000831117156107ca57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135611dd0565b61034b6004803603608081101561080757600080fd5b8135919081019060408101602082013564010000000081111561082957600080fd5b82018360208201111561083b57600080fd5b8035906020019184602083028401116401000000008311171561085d57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561213e565b34801561089057600080fd5b50610294600480360360608110156108a757600080fd5b5080359060208101359060400135612562565b3480156108c657600080fd5b5061034b600480360360a08110156108dd57600080fd5b81359160208101359181019060608101604082013564010000000081111561090457600080fd5b82018360208201111561091657600080fd5b8035906020019184602083028401116401000000008311171561093857600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff813516906020013561256f565b34801561096b57600080fd5b506109746126b2565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b3480156109a957600080fd5b50610294600480360360608110156109c057600080fd5b50803590602081013590604001356126d6565b3480156109df57600080fd5b50610294600480360360c08110156109f657600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a001356126e3565b6101de60048036036080811015610a4957600080fd5b81359190810190604081016020820135640100000000811115610a6b57600080fd5b820183602082011115610a7d57600080fd5b80359060200191846020830284011164010000000083111715610a9f57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff81351690602001356128c3565b348015610ad257600080fd5b50610245600480360360e0811015610ae957600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359091169060c00135612da6565b348015610b3c57600080fd5b506109746130b0565b348015610b5157600080fd5b506109746130d4565b348015610b6657600080fd5b5061034b60048036036040811015610b7d57600080fd5b81359190810190604081016020820135640100000000811115610b9f57600080fd5b820183602082011115610bb157600080fd5b80359060200191846020830284011164010000000083111715610bd357600080fd5b9190808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152509295506130f0945050505050565b348015610c1d57600080fd5b506102456004803603610140811015610c3557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a08101359060c081013515159060ff60e08201351690610100810135906101200135613120565b348015610c9d57600080fd5b50610d006004803603610100811015610cb557600080fd5b5073ffffffffffffffffffffffffffffffffffffffff8135811691602081013582169160408201359160608101359160808201359160a08101359160c0820135169060e00135613278565b60408051938452602084019290925282820152519081900360600190f35b610d00600480360360c0811015610d3457600080fd5b5073ffffffffffffffffffffffffffffffffffffffff81358116916020810135916040820135916060810135916080820135169060a00135613407565b61034b60048036036080811015610d8757600080fd5b81359190810190604081016020820135640100000000811115610da957600080fd5b820183602082011115610dbb57600080fd5b80359060200191846020830284011164010000000083111715610ddd57600080fd5b919350915073ffffffffffffffffffffffffffffffffffffffff8135169060200135613733565b6000808242811015610e7757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b610ea6897f00000000000000000000000000000000000000000000000000000000000000008a8a8a308a612da6565b9093509150610eb6898685613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b158015610f2957600080fd5b505af1158015610f3d573d6000803e3d6000fd5b50505050610f4b8583613d4d565b50965096945050505050565b6000610f64848484613e8a565b949350505050565b60608142811015610fde57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061104357fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16146110e257604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6111497f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b613fcd565b9150868260018451038151811061115c57fe5b602002602001015110156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b611280868660008181106111cb57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16336112667f00000000000000000000000000000000000000000000000000000000000000008a8a600081811061121a57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168b8b600181811061124457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff16614135565b8560008151811061127357fe5b6020026020010151614220565b6112bf828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152503092506143f0915050565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d8360018551038151811061130b57fe5b60200260200101516040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561134957600080fd5b505af115801561135d573d6000803e3d6000fd5b50505050611382848360018551038151811061137557fe5b6020026020010151613d4d565b509695505050505050565b60606113c27f000000000000000000000000000000000000000000000000000000000000000084846113bd613fae565b614677565b90505b92915050565b60008060006113fb7f00000000000000000000000000000000000000000000000000000000000000008f8f614135565b905060008761140a578c61142c565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b1580156114c857600080fd5b505af11580156114dc573d6000803e3d6000fd5b505050506114ef8f8f8f8f8f8f8f612da6565b809450819550505050509b509b9950505050505050505050565b6060814281101561157b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6115dd7f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b915086826001845103815181106115f057fe5b6020026020010151101561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b61165f868660008181106111cb57fe5b611382828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b6060814281101561171057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001686867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff810181811061177557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461181457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6118767f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061188657fe5b602002602001015111156111bb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b6000806119337f00000000000000000000000000000000000000000000000000000000000000008d7f0000000000000000000000000000000000000000000000000000000000000000614135565b9050600086611942578b611964565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018b905260ff8916608482015260a4810188905260c48101879052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b158015611a0057600080fd5b505af1158015611a14573d6000803e3d6000fd5b50505050611a268d8d8d8d8d8d6126e3565b9d9c50505050505050505050505050565b8042811015611aa757604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b611b3685856000818110611ab757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1633611b307f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff168a8a600181811061124457fe5b8a614220565b600085857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611b6657fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231856040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611bff57600080fd5b505afa158015611c13573d6000803e3d6000fd5b505050506040513d6020811015611c2957600080fd5b50516040805160208881028281018201909352888252929350611c6b929091899189918291850190849080828437600092019190915250889250614806915050565b86611d6f8288887fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611c9e57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b505afa158015611d4b573d6000803e3d6000fd5b505050506040513d6020811015611d6157600080fd5b50519063ffffffff614b9916565b1015611dc6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b5050505050505050565b8042811015611e4057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b73ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001685857fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110611ea557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614611f4457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b611f5485856000818110611ab757fe5b611f92858580806020026020016040519081016040528093929190818152602001838360200280828437600092019190915250309250614806915050565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905160009173ffffffffffffffffffffffffffffffffffffffff7f000000000000000000000000000000000000000000000000000000000000000016916370a0823191602480820192602092909190829003018186803b15801561202257600080fd5b505afa158015612036573d6000803e3d6000fd5b505050506040513d602081101561204c57600080fd5b50519050868110156120a9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d826040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b15801561211c57600080fd5b505af1158015612130573d6000803e3d6000fd5b50505050611dc68482613d4d565b606081428110156121b057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106121f457fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461229357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6122f57f0000000000000000000000000000000000000000000000000000000000000000348888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506111449250613fae915050565b9150868260018451038151811061230857fe5b60200260200101511015612367576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b8152602001806157e7602b913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106123b057fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156123e357600080fd5b505af11580156123f7573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb6124697f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b8460008151811061247657fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b1580156124e757600080fd5b505af11580156124fb573d6000803e3d6000fd5b505050506040513d602081101561251157600080fd5b505161251957fe5b612558828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b5095945050505050565b6000610f64848484614c0b565b606081428110156125e157604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6126437f0000000000000000000000000000000000000000000000000000000000000000898888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b9150868260008151811061265357fe5b6020026020010151111561164f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000081565b6000610f64848484614d2f565b6000814281101561275557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b612784887f00000000000000000000000000000000000000000000000000000000000000008989893089612da6565b604080517f70a08231000000000000000000000000000000000000000000000000000000008152306004820152905191945061282e92508a91879173ffffffffffffffffffffffffffffffffffffffff8416916370a0823191602480820192602092909190829003018186803b1580156127fd57600080fd5b505afa158015612811573d6000803e3d6000fd5b505050506040513d602081101561282757600080fd5b5051613b86565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16632e1a7d4d836040518263ffffffff1660e01b815260040180828152602001915050600060405180830381600087803b1580156128a157600080fd5b505af11580156128b5573d6000803e3d6000fd5b505050506113828483613d4d565b804281101561293357604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff168585600081811061297757fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1614612a1657604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b60003490507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0826040518263ffffffff1660e01b81526004016000604051808303818588803b158015612a8357600080fd5b505af1158015612a97573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb612b097f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b836040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015612b7357600080fd5b505af1158015612b87573d6000803e3d6000fd5b505050506040513d6020811015612b9d57600080fd5b5051612ba557fe5b600086867fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612bd557fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231866040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015612c6e57600080fd5b505afa158015612c82573d6000803e3d6000fd5b505050506040513d6020811015612c9857600080fd5b50516040805160208981028281018201909352898252929350612cda9290918a918a918291850190849080828437600092019190915250899250614806915050565b87611d6f8289897fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8101818110612d0d57fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166370a08231896040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b6000808242811015612e1957604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6000612e467f00000000000000000000000000000000000000000000000000000000000000008c8c614135565b604080517f23b872dd00000000000000000000000000000000000000000000000000000000815233600482015273ffffffffffffffffffffffffffffffffffffffff831660248201819052604482018d9052915192935090916323b872dd916064808201926020929091908290030181600087803b158015612ec757600080fd5b505af1158015612edb573d6000803e3d6000fd5b505050506040513d6020811015612ef157600080fd5b5050604080517f89afcb4400000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015282516000938493928616926389afcb44926024808301939282900301818787803b158015612f6457600080fd5b505af1158015612f78573d6000803e3d6000fd5b505050506040513d6040811015612f8e57600080fd5b50805160209091015190925090506000612fa88e8e614e0f565b5090508073ffffffffffffffffffffffffffffffffffffffff168e73ffffffffffffffffffffffffffffffffffffffff1614612fe5578183612fe8565b82825b90975095508a871015613046576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b8986101561309f576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b505050505097509795505050505050565b7f000000000000000000000000000000000000000000000000000000000000000081565b60005473ffffffffffffffffffffffffffffffffffffffff1681565b60606113c27f00000000000000000000000000000000000000000000000000000000000000008484611144613fae565b60008060006131707f00000000000000000000000000000000000000000000000000000000000000008e7f0000000000000000000000000000000000000000000000000000000000000000614135565b905060008761317f578c6131a1565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5b604080517fd505accf00000000000000000000000000000000000000000000000000000000815233600482015230602482015260448101839052606481018c905260ff8a16608482015260a4810189905260c48101889052905191925073ffffffffffffffffffffffffffffffffffffffff84169163d505accf9160e48082019260009290919082900301818387803b15801561323d57600080fd5b505af1158015613251573d6000803e3d6000fd5b505050506132638e8e8e8e8e8e610e04565b909f909e509c50505050505050505050505050565b600080600083428110156132ed57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6132fb8c8c8c8c8c8c614f62565b9094509250600061332d7f00000000000000000000000000000000000000000000000000000000000000008e8e614135565b905061333b8d338388614220565b6133478c338387614220565b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156133c657600080fd5b505af11580156133da573d6000803e3d6000fd5b505050506040513d60208110156133f057600080fd5b5051949d939c50939a509198505050505050505050565b6000806000834281101561347c57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b6134aa8a7f00000000000000000000000000000000000000000000000000000000000000008b348c8c614f62565b909450925060006134fc7f00000000000000000000000000000000000000000000000000000000000000008c7f0000000000000000000000000000000000000000000000000000000000000000614135565b905061350a8b338388614220565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0856040518263ffffffff1660e01b81526004016000604051808303818588803b15801561357257600080fd5b505af1158015613586573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb82866040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b15801561363257600080fd5b505af1158015613646573d6000803e3d6000fd5b505050506040513d602081101561365c57600080fd5b505161366457fe5b8073ffffffffffffffffffffffffffffffffffffffff16636a627842886040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001915050602060405180830381600087803b1580156136e357600080fd5b505af11580156136f7573d6000803e3d6000fd5b505050506040513d602081101561370d57600080fd5b50519250348410156137255761372533853403613d4d565b505096509650969350505050565b606081428110156137a557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f556e69737761705632526f757465723a20455850495245440000000000000000604482015290519081900360640190fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16868660008181106137e957fe5b9050602002013573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161461388857604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f556e69737761705632526f757465723a20494e56414c49445f50415448000000604482015290519081900360640190fd5b6138ea7f0000000000000000000000000000000000000000000000000000000000000000888888808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152506113bd9250613fae915050565b915034826000815181106138fa57fe5b60200260200101511115613959576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602781526020018061579a6027913960400191505060405180910390fd5b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663d0e30db0836000815181106139a257fe5b60200260200101516040518263ffffffff1660e01b81526004016000604051808303818588803b1580156139d557600080fd5b505af11580156139e9573d6000803e3d6000fd5b50505050507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663a9059cbb613a5b7f000000000000000000000000000000000000000000000000000000000000000089896000818110611b0657fe5b84600081518110613a6857fe5b60200260200101516040518363ffffffff1660e01b8152600401808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200182815260200192505050602060405180830381600087803b158015613ad957600080fd5b505af1158015613aed573d6000803e3d6000fd5b505050506040513d6020811015613b0357600080fd5b5051613b0b57fe5b613b4a828787808060200260200160405190810160405280939291908181526020018383602002808284376000920191909152508992506143f0915050565b81600081518110613b5757fe5b6020026020010151341115612558576125583383600081518110613b7757fe5b60200260200101513403613d4d565b6040805173ffffffffffffffffffffffffffffffffffffffff8481166024830152604480830185905283518084039091018152606490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167fa9059cbb00000000000000000000000000000000000000000000000000000000178152925182516000946060949389169392918291908083835b60208310613c5c57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613c1f565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114613cbe576040519150601f19603f3d011682016040523d82523d6000602084013e613cc3565b606091505b5091509150818015613cf1575080511580613cf15750808060200190516020811015613cee57600080fd5b50515b613d46576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602d815260200180615812602d913960400191505060405180910390fd5b5050505050565b6040805160008082526020820190925273ffffffffffffffffffffffffffffffffffffffff84169083906040518082805190602001908083835b60208310613dc457805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe09092019160209182019101613d87565b6001836020036101000a03801982511681845116808217855250505050505090500191505060006040518083038185875af1925050503d8060008114613e26576040519150601f19603f3d011682016040523d82523d6000602084013e613e2b565b606091505b5050905080613e85576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260348152602001806156ce6034913960400191505060405180910390fd5b505050565b6000808411613ee4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b600083118015613ef45750600082115b613f49576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000613f5d856103e563ffffffff61526316565b90506000613f71828563ffffffff61526316565b90506000613f9783613f8b886103e863ffffffff61526316565b9063ffffffff6152e916565b9050808281613fa257fe5b04979650505050505050565b60005473ffffffffffffffffffffffffffffffffffffffff1633141590565b606060028351101561404057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561405857600080fd5b50604051908082528060200260200182016040528015614082578160200160208202803683370190505b509050838160008151811061409357fe5b60200260200101818152505060005b600184510381101561412c576000806140e5888785815181106140c157fe5b60200260200101518886600101815181106140d857fe5b602002602001015161535b565b915091506141088484815181106140f857fe5b6020026020010151838388615443565b84846001018151811061411757fe5b602090810291909101015250506001016140a2565b50949350505050565b60008060006141448585614e0f565b604080517fffffffffffffffffffffffffffffffffffffffff000000000000000000000000606094851b811660208084019190915293851b81166034830152825160288184030181526048830184528051908501207fff0000000000000000000000000000000000000000000000000000000000000060688401529a90941b9093166069840152607d8301989098527f96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f609d808401919091528851808403909101815260bd909201909752805196019590952095945050505050565b6040805173ffffffffffffffffffffffffffffffffffffffff85811660248301528481166044830152606480830185905283518084039091018152608490920183526020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff167f23b872dd0000000000000000000000000000000000000000000000000000000017815292518251600094606094938a169392918291908083835b602083106142fe57805182527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe090920191602091820191016142c1565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114614360576040519150601f19603f3d011682016040523d82523d6000602084013e614365565b606091505b5091509150818015614393575080511580614393575080806020019051602081101561439057600080fd5b50515b6143e8576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252603181526020018061569d6031913960400191505060405180910390fd5b505050505050565b60005b60018351038110156146715760008084838151811061440e57fe5b602002602001015185846001018151811061442557fe5b602002602001015191509150600061443d8383614e0f565b509050600087856001018151811061445157fe5b602002602001015190506000808373ffffffffffffffffffffffffffffffffffffffff168673ffffffffffffffffffffffffffffffffffffffff16146144995782600061449d565b6000835b91509150600060028a510388106144b457886144f5565b6144f57f0000000000000000000000000000000000000000000000000000000000000000878c8b600201815181106144e857fe5b6020026020010151614135565b90506145227f00000000000000000000000000000000000000000000000000000000000000008888614135565b73ffffffffffffffffffffffffffffffffffffffff1663022c0d9f84848460006040519080825280601f01601f19166020018201604052801561456c576020820181803683370190505b506040518563ffffffff1660e01b8152600401808581526020018481526020018373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200180602001828103825283818151815260200191508051906020019080838360005b838110156145f75781810151838201526020016145df565b50505050905090810190601f1680156146245780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b15801561464657600080fd5b505af115801561465a573d6000803e3d6000fd5b5050600190990198506143f3975050505050505050565b50505050565b60606002835110156146ea57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a20494e56414c49445f504154480000604482015290519081900360640190fd5b825167ffffffffffffffff8111801561470257600080fd5b5060405190808252806020026020018201604052801561472c578160200160208202803683370190505b509050838160018351038151811061474057fe5b602090810291909101015282517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff015b801561412c576000806147a08887600186038151811061478c57fe5b60200260200101518886815181106140d857fe5b915091506147c38484815181106147b357fe5b6020026020010151838388615571565b8460018503815181106147d257fe5b602090810291909101015250507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01614770565b60005b6001835103811015613e855760008084838151811061482457fe5b602002602001015185846001018151811061483b57fe5b60200260200101519150915060006148538383614e0f565b50905060006148837f00000000000000000000000000000000000000000000000000000000000000008585614135565b90506000806000808473ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156148d157600080fd5b505afa1580156148e5573d6000803e3d6000fd5b505050506040513d60608110156148fb57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905060008073ffffffffffffffffffffffffffffffffffffffff8a811690891614614945578284614948565b83835b915091506149cd828b73ffffffffffffffffffffffffffffffffffffffff166370a082318a6040518263ffffffff1660e01b8152600401808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060206040518083038186803b158015611d3757600080fd5b95506149da868383613e8a565b9450505050506000808573ffffffffffffffffffffffffffffffffffffffff168873ffffffffffffffffffffffffffffffffffffffff1614614a1e57826000614a22565b6000835b91509150600060028c51038a10614a39578a614a6d565b614a6d7f0000000000000000000000000000000000000000000000000000000000000000898e8d600201815181106144e857fe5b60408051600080825260208201928390527f022c0d9f000000000000000000000000000000000000000000000000000000008352602482018781526044830187905273ffffffffffffffffffffffffffffffffffffffff8086166064850152608060848501908152845160a48601819052969750908c169563022c0d9f958a958a958a9591949193919260c486019290918190849084905b83811015614b1d578181015183820152602001614b05565b50505050905090810190601f168015614b4a5780820380516001836020036101000a031916815260200191505b5095505050505050600060405180830381600087803b158015614b6c57600080fd5b505af1158015614b80573d6000803e3d6000fd5b50506001909b019a506148099950505050505050505050565b808203828111156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601560248201527f64732d6d6174682d7375622d756e646572666c6f770000000000000000000000604482015290519081900360640190fd5b6000808411614c65576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b600083118015614c755750600082115b614cca576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b6000614cee6103e8614ce2868863ffffffff61526316565b9063ffffffff61526316565b90506000614d086103e5614ce2868963ffffffff614b9916565b9050614d256001828481614d1857fe5b049063ffffffff6152e916565b9695505050505050565b6000808411614d89576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157756025913960400191505060405180910390fd5b600083118015614d995750600082115b614dee576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b82614dff858463ffffffff61526316565b81614e0657fe5b04949350505050565b6000808273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff161415614e97576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260258152602001806157026025913960400191505060405180910390fd5b8273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff1610614ed1578284614ed4565b83835b909250905073ffffffffffffffffffffffffffffffffffffffff8216614f5b57604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601e60248201527f556e697377617056324c6962726172793a205a45524f5f414444524553530000604482015290519081900360640190fd5b9250929050565b604080517fe6a4390500000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff888116600483015287811660248301529151600092839283927f00000000000000000000000000000000000000000000000000000000000000009092169163e6a4390591604480820192602092909190829003018186803b15801561500257600080fd5b505afa158015615016573d6000803e3d6000fd5b505050506040513d602081101561502c57600080fd5b505173ffffffffffffffffffffffffffffffffffffffff16141561511257604080517fc9c6539600000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff8a81166004830152898116602483015291517f00000000000000000000000000000000000000000000000000000000000000009092169163c9c65396916044808201926020929091908290030181600087803b1580156150e557600080fd5b505af11580156150f9573d6000803e3d6000fd5b505050506040513d602081101561510f57600080fd5b50505b6000806151407f00000000000000000000000000000000000000000000000000000000000000008b8b61535b565b91509150816000148015615152575080155b1561516257879350869250615256565b600061516f898484614d2f565b90508781116151dc57858110156151d1576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157276026913960400191505060405180910390fd5b889450925082615254565b60006151e9898486614d2f565b9050898111156151f557fe5b8781101561524e576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260268152602001806157c16026913960400191505060405180910390fd5b94508793505b505b5050965096945050505050565b600081158061527e5750508082028282828161527b57fe5b04145b6113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6d756c2d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b808201828110156113c557604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601460248201527f64732d6d6174682d6164642d6f766572666c6f77000000000000000000000000604482015290519081900360640190fd5b600080600061536a8585614e0f565b50905060008061537b888888614135565b73ffffffffffffffffffffffffffffffffffffffff16630902f1ac6040518163ffffffff1660e01b815260040160606040518083038186803b1580156153c057600080fd5b505afa1580156153d4573d6000803e3d6000fd5b505050506040513d60608110156153ea57600080fd5b5080516020909101516dffffffffffffffffffffffffffff918216935016905073ffffffffffffffffffffffffffffffffffffffff87811690841614615431578082615434565b81815b90999098509650505050505050565b6000811561545d57615456858585613e8a565b9050610f64565b600085116154b6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602b81526020018061583f602b913960400191505060405180910390fd5b6000841180156154c65750600083115b61551b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061552f866103e863ffffffff61526316565b90506000615543828663ffffffff61526316565b90506000615559876103e863ffffffff61526316565b905080828161556457fe5b0498975050505050505050565b6000811561558457615456858585614c0b565b600085116155dd576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602c815260200180615671602c913960400191505060405180910390fd5b6000841180156155ed5750600083115b615642576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252602881526020018061574d6028913960400191505060405180910390fd5b600061565a6103e8614ce2878963ffffffff61526316565b90506000613f97856103e863ffffffff6152631656fe556e697377617056324c6962726172793a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a7472616e7366657246726f6d3a207472616e7366657246726f6d206661696c65645472616e7366657248656c7065723a3a736166655472616e736665724554483a20455448207472616e73666572206661696c6564556e697377617056324c6962726172793a204944454e544943414c5f414444524553534553556e69737761705632526f757465723a20494e53554646494349454e545f425f414d4f554e54556e697377617056324c6962726172793a20494e53554646494349454e545f4c4951554944495459556e697377617056324c6962726172793a20494e53554646494349454e545f414d4f554e54556e69737761705632526f757465723a204558434553534956455f494e5055545f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f415f414d4f554e54556e69737761705632526f757465723a20494e53554646494349454e545f4f55545055545f414d4f554e545472616e7366657248656c7065723a3a736166655472616e736665723a207472616e73666572206661696c6564556e697377617056324c6962726172793a20494e53554646494349454e545f494e5055545f414d4f554e54a2646970667358221220727ddc3491766f9b8dc46e1c4bafbfdb094815ade2af57a4703d38a9b8e4709c64736f6c63430006060033"
+}

--- a/test/lib/MathHelper.ts
+++ b/test/lib/MathHelper.ts
@@ -54,7 +54,7 @@ describe("Math Helper", function () {
 
       const contract = await loadFixture(deployMathHelper);
 
-      const converted = await contract.read.calculatePriceRatio([
+      const converted = await contract.read.calculatePriceRatioUniV4([
         sqrtpricex96,
         18,
       ]);
@@ -89,7 +89,7 @@ describe("Math Helper", function () {
 
       const contract = await loadFixture(deployMathHelper);
 
-      const ratio = await contract.read.calculatePriceRatio([sqrtpricex96, 18]);
+      const ratio = await contract.read.calculatePriceRatioUniV4([sqrtpricex96, 18]);
 
       expect(ratio).to.equal(expectedRatio);
 

--- a/test/lib/MathHelper.ts
+++ b/test/lib/MathHelper.ts
@@ -5,6 +5,7 @@ import {
 import { expect } from "chai";
 import hre from "hardhat";
 import { formatEther, parseEther } from "viem";
+import * as helper from "../helper/TestHelper";
 
 describe("Math Helper", function () {
   async function deployMathHelper() {
@@ -89,7 +90,10 @@ describe("Math Helper", function () {
 
       const contract = await loadFixture(deployMathHelper);
 
-      const ratio = await contract.read.calculatePriceRatioUniV4([sqrtpricex96, 18]);
+      const ratio = await contract.read.calculatePriceRatioUniV4([
+        sqrtpricex96,
+        18,
+      ]);
 
       expect(ratio).to.equal(expectedRatio);
 
@@ -142,6 +146,84 @@ describe("Math Helper", function () {
 
       expect(withdraw).to.equal(parseEther("0.3"));
       expect(amm).to.equal(parseEther("0.7"));
+    });
+
+    it("should calculate Uniswap v2 LP value correctly(simple round math)", async function () {
+      const contract = await loadFixture(deployMathHelper);
+
+      const totalLpSupply = parseEther("10");
+      const raReserve = parseEther("10");
+      const ctReserve = parseEther("10");
+
+      const [ra, ct] = await contract.read.calculateUniV2LpValue([
+        totalLpSupply,
+        raReserve,
+        ctReserve,
+      ]);
+
+      expect(ra).to.equal(parseEther("1"));
+      expect(ct).to.equal(parseEther("1"));
+    });
+
+    it("should calculate Uniswap v2 LP value correctly(float math)", async function () {
+      const contract = await loadFixture(deployMathHelper);
+
+      const totalLpSupply = parseEther("10");
+      const raReserve = parseEther("0.5");
+      const ctReserve = parseEther("0.2");
+
+      const [ra, ct] = await contract.read.calculateUniV2LpValue([
+        totalLpSupply,
+        raReserve,
+        ctReserve,
+      ]);
+
+      expect(ra).to.equal(parseEther("0.05"));
+      expect(ct).to.equal(parseEther("0.02"));
+    });
+
+    it("should calculate LV token value relative to uni v2 LP(simple round math)", async function () {
+      const contract = await loadFixture(deployMathHelper);
+
+      const totalLpSupply = parseEther("100");
+      const totalLpOwned = parseEther("10");
+      const raReserve = parseEther("10");
+      const ctReserve = parseEther("10");
+      const lvSupply = parseEther("10");
+
+      const [raValuePerLv, ctValuePerLV] =
+        await contract.read.calculateLvValueFromUniV2Lp([
+          totalLpSupply,
+          totalLpOwned,
+          raReserve,
+          ctReserve,
+          lvSupply,
+        ]);
+
+      expect(raValuePerLv).to.equal(parseEther("0.1"));
+      expect(ctValuePerLV).to.equal(parseEther("0.1"));
+    });
+
+    it("should calculate LV token value relative to uni v2 LP(float math)", async function () {
+      const contract = await loadFixture(deployMathHelper);
+
+      const totalLpSupply = parseEther("100");
+      const totalLpOwned = parseEther("5");
+      const raReserve = parseEther("0.8");
+      const ctReserve = parseEther("0.8");
+      const lvSupply = parseEther("100");
+
+      const [raValuePerLv, ctValuePerLV] =
+        await contract.read.calculateLvValueFromUniV2Lp([
+          totalLpSupply,
+          totalLpOwned,
+          raReserve,
+          ctReserve,
+          lvSupply,
+        ]);
+
+      expect(raValuePerLv).to.equal(parseEther("0.0004"));
+      expect(ctValuePerLV).to.equal(parseEther("0.0004"));
     });
   });
 
@@ -262,16 +344,9 @@ describe("Math Helper", function () {
           rate3,
         ]);
 
-      console.log(`got ${formatEther(deposit3)} DS from deposit`);
-      console.log(
-        `redeeeming ${formatEther(deposit3)} DS with rate ${formatEther(rate3)}`
-      );
-
       const redeem3 = await contract.read.calculateRedeemAmountWithExchangeRate(
         [deposit3, rate3]
       );
-
-      console.log(`redeemed ${formatEther(redeem3)} RA`);
 
       expect(redeem3).to.equal(amount);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,119 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@ethereum-waffle/chai@4.0.10":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/chai/-/chai-4.0.10.tgz#6f600a40b6fdaed331eba42b8625ff23f3a0e59a"
+  integrity sha512-X5RepE7Dn8KQLFO7HHAAe+KeGaX/by14hn90wePGBhzL54tq4Y8JscZFu+/LCwCl6TnkAAy5ebiMoqJ37sFtWw==
+  dependencies:
+    "@ethereum-waffle/provider" "4.0.5"
+    debug "^4.3.4"
+    json-bigint "^1.0.0"
+
+"@ethereum-waffle/compiler@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/compiler/-/compiler-4.0.3.tgz#069e2df24b879b8a7b78857bad6f8bf6ebc8a5b1"
+  integrity sha512-5x5U52tSvEVJS6dpCeXXKvRKyf8GICDwiTwUvGD3/WD+DpvgvaoHOL82XqpTSUHgV3bBq6ma5/8gKUJUIAnJCw==
+  dependencies:
+    "@resolver-engine/imports" "^0.3.3"
+    "@resolver-engine/imports-fs" "^0.3.3"
+    "@typechain/ethers-v5" "^10.0.0"
+    "@types/mkdirp" "^0.5.2"
+    "@types/node-fetch" "^2.6.1"
+    mkdirp "^0.5.1"
+    node-fetch "^2.6.7"
+
+"@ethereum-waffle/ens@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/ens/-/ens-4.0.3.tgz#4a46ac926414f3c83b4e8cc2562c8e2aee06377a"
+  integrity sha512-PVLcdnTbaTfCrfSOrvtlA9Fih73EeDvFS28JQnT5M5P4JMplqmchhcZB1yg/fCtx4cvgHlZXa0+rOCAk2Jk0Jw==
+
+"@ethereum-waffle/mock-contract@4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/mock-contract/-/mock-contract-4.0.4.tgz#f13fea29922d87a4d2e7c4fc8fe72ea04d2c13de"
+  integrity sha512-LwEj5SIuEe9/gnrXgtqIkWbk2g15imM/qcJcxpLyAkOj981tQxXmtV4XmQMZsdedEsZ/D/rbUAOtZbgwqgUwQA==
+
+"@ethereum-waffle/provider@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@ethereum-waffle/provider/-/provider-4.0.5.tgz#8a65dbf0263f4162c9209608205dee1c960e716b"
+  integrity sha512-40uzfyzcrPh+Gbdzv89JJTMBlZwzya1YLDyim8mVbEqYLP5VRYWoGp0JMyaizgV3hMoUFRqJKVmIUw4v7r3hYw==
+  dependencies:
+    "@ethereum-waffle/ens" "4.0.3"
+    "@ganache/ethereum-options" "0.1.4"
+    debug "^4.3.4"
+    ganache "7.4.3"
+
+"@ethereumjs/block@^3.5.0", "@ethereumjs/block@^3.6.0", "@ethereumjs/block@^3.6.2":
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.6.3.tgz#d96cbd7af38b92ebb3424223dbf773f5ccd27f84"
+  integrity sha512-CegDeryc2DVKnDkg5COQrE0bJfw/p0v3GBk2W5/Dj5dOVfEmb50Ux0GLnSPypooLnfqjwFaorGuT9FokWB3GRg==
+  dependencies:
+    "@ethereumjs/common" "^2.6.5"
+    "@ethereumjs/tx" "^3.5.2"
+    ethereumjs-util "^7.1.5"
+    merkle-patricia-tree "^4.2.4"
+
+"@ethereumjs/blockchain@^5.5.0":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.5.3.tgz#aa49a6a04789da6b66b5bcbb0d0b98efc369f640"
+  integrity sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==
+  dependencies:
+    "@ethereumjs/block" "^3.6.2"
+    "@ethereumjs/common" "^2.6.4"
+    "@ethereumjs/ethash" "^1.1.0"
+    debug "^4.3.3"
+    ethereumjs-util "^7.1.5"
+    level-mem "^5.0.1"
+    lru-cache "^5.1.1"
+    semaphore-async-await "^1.5.1"
+
+"@ethereumjs/common@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.6.0.tgz#feb96fb154da41ee2cc2c5df667621a440f36348"
+  integrity sha512-Cq2qS0FTu6O2VU1sgg+WyU9Ps0M6j/BEMHN+hRaECXCV/r0aI78u4N6p52QW/BDVhwWZpCdrvG8X7NJdzlpNUA==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.3"
+
+"@ethereumjs/common@^2.6.0", "@ethereumjs/common@^2.6.4", "@ethereumjs/common@^2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.6.5.tgz#0a75a22a046272579d91919cb12d84f2756e8d30"
+  integrity sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.5"
+
+"@ethereumjs/ethash@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/ethash/-/ethash-1.1.0.tgz#7c5918ffcaa9cb9c1dc7d12f77ef038c11fb83fb"
+  integrity sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==
+  dependencies:
+    "@ethereumjs/block" "^3.5.0"
+    "@types/levelup" "^4.3.0"
+    buffer-xor "^2.0.1"
+    ethereumjs-util "^7.1.1"
+    miller-rabin "^4.0.0"
+
 "@ethereumjs/rlp@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
   integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
+
+"@ethereumjs/tx@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.4.0.tgz#7eb1947eefa55eb9cf05b3ca116fb7a3dbd0bce7"
+  integrity sha512-WWUwg1PdjHKZZxPPo274ZuPsJCWV3SqATrEKQP1n2DrVYVP1aZIYpo/mFaA0BDoE0tIQmBeimRCEA0Lgil+yYw==
+  dependencies:
+    "@ethereumjs/common" "^2.6.0"
+    ethereumjs-util "^7.1.3"
+
+"@ethereumjs/tx@^3.4.0", "@ethereumjs/tx@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.5.2.tgz#197b9b6299582ad84f9527ca961466fce2296c1c"
+  integrity sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==
+  dependencies:
+    "@ethereumjs/common" "^2.6.4"
+    ethereumjs-util "^7.1.5"
 
 "@ethereumjs/util@^8.1.0":
   version "8.1.0"
@@ -94,7 +203,40 @@
     ethereum-cryptography "^2.0.0"
     micro-ftch "^0.3.1"
 
-"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.9", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.7.0":
+"@ethereumjs/vm@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.6.0.tgz#e0ca62af07de820143674c30b776b86c1983a464"
+  integrity sha512-J2m/OgjjiGdWF2P9bj/4LnZQ1zRoZhY8mRNVw/N3tXliGI8ai1sI1mlDPkLpeUUM4vq54gH6n0ZlSpz8U/qlYQ==
+  dependencies:
+    "@ethereumjs/block" "^3.6.0"
+    "@ethereumjs/blockchain" "^5.5.0"
+    "@ethereumjs/common" "^2.6.0"
+    "@ethereumjs/tx" "^3.4.0"
+    async-eventemitter "^0.2.4"
+    core-js-pure "^3.0.1"
+    debug "^2.2.0"
+    ethereumjs-util "^7.1.3"
+    functional-red-black-tree "^1.0.1"
+    mcl-wasm "^0.7.1"
+    merkle-patricia-tree "^4.2.2"
+    rustbn.js "~0.2.0"
+
+"@ethersproject/abi@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.0.tgz#ea07cbc1eec2374d32485679c12408005895e9f3"
+  integrity sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.9", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.6.0", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
   integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
@@ -109,7 +251,20 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
+"@ethersproject/abstract-provider@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.6.0", "@ethersproject/abstract-provider@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
   integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
@@ -122,7 +277,18 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
-"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
+"@ethersproject/abstract-signer@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.6.0", "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
   integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
@@ -132,6 +298,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/address@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
 
 "@ethersproject/address@5.6.1":
   version "5.6.1"
@@ -144,7 +321,7 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.1"
 
-"@ethersproject/address@5.7.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0":
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.6.0", "@ethersproject/address@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
   integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
@@ -155,14 +332,29 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
-"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
+"@ethersproject/base64@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+
+"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.6.0", "@ethersproject/base64@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
 
-"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
+"@ethersproject/basex@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.0.tgz#9ea7209bf0a1c3ddc2a90f180c3a7f0d7d2e8a69"
+  integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.6.0", "@ethersproject/basex@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
   integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
@@ -170,7 +362,16 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
 
-"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.6.2", "@ethersproject/bignumber@^5.7.0":
+"@ethersproject/bignumber@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.6.0", "@ethersproject/bignumber@^5.6.2", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
   integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
@@ -179,19 +380,49 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.7.0":
+"@ethersproject/bytes@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
+  integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.6.0", "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
   integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
+"@ethersproject/constants@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.6.0", "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/contracts@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
+  integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
+  dependencies:
+    "@ethersproject/abi" "^5.6.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
 
 "@ethersproject/contracts@5.7.0":
   version "5.7.0"
@@ -209,7 +440,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
 
-"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+"@ethersproject/hash@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.6.0", "@ethersproject/hash@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
   integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
@@ -224,7 +469,25 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
+"@ethersproject/hdnode@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.0.tgz#9dcbe8d629bbbcf144f2cae476337fe92d320998"
+  integrity sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
+"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.6.0", "@ethersproject/hdnode@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
   integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
@@ -242,7 +505,26 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
-"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
+"@ethersproject/json-wallets@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz#4c2fc27f17e36c583e7a252fb938bc46f98891e5"
+  integrity sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.6.0", "@ethersproject/json-wallets@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
   integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
@@ -261,7 +543,15 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
-"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.6.1", "@ethersproject/keccak256@^5.7.0":
+"@ethersproject/keccak256@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.6.0", "@ethersproject/keccak256@^5.6.1", "@ethersproject/keccak256@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
   integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
@@ -269,19 +559,39 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/logger@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
 "@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.6.0", "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
-"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+"@ethersproject/networks@5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.1.tgz#7a21ed1f83e86121737b16841961ec99ccf5c9c7"
+  integrity sha512-b2rrupf3kCTcc3jr9xOWBuHylSFtbpJf79Ga7QR98ienU2UqGimPGEsYMgbI29KHJfA5Us89XwGVmxrlxmSrMg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.6.0", "@ethersproject/networks@^5.7.0":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
+"@ethersproject/pbkdf2@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
+  integrity sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+
+"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.6.0", "@ethersproject/pbkdf2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
   integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
@@ -289,12 +599,44 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/sha2" "^5.7.0"
 
-"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
+"@ethersproject/properties@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.6.0", "@ethersproject/properties@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.2.tgz#b9807b1c8c6f59fa2ee4b3cf6519724d07a9f422"
+  integrity sha512-6/EaFW/hNWz+224FXwl8+HdMRzVHt8DpPmu5MZaIQqx/K/ELnC9eY236SMV7mleCM3NnEArFwcAAxH5kUUgaRg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
 
 "@ethersproject/providers@5.7.2":
   version "5.7.2"
@@ -322,7 +664,15 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
+"@ethersproject/random@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
+  integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/random@5.7.0", "@ethersproject/random@^5.6.0", "@ethersproject/random@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
   integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
@@ -330,7 +680,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.6.1", "@ethersproject/rlp@^5.7.0":
+"@ethersproject/rlp@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.6.0", "@ethersproject/rlp@^5.6.1", "@ethersproject/rlp@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
   integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
@@ -338,7 +696,16 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
+"@ethersproject/sha2@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.6.0", "@ethersproject/sha2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
   integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
@@ -347,7 +714,19 @@
     "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
-"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
+"@ethersproject/signing-key@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.0.tgz#4f02e3fb09e22b71e2e1d6dc4bcb5dafa69ce042"
+  integrity sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.6.0", "@ethersproject/signing-key@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
   integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
@@ -358,6 +737,18 @@
     bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
+
+"@ethersproject/solidity@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.0.tgz#64657362a596bf7f5630bdc921c07dd78df06dc3"
+  integrity sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/solidity@5.7.0":
   version "5.7.0"
@@ -371,7 +762,16 @@
     "@ethersproject/sha2" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
+"@ethersproject/strings@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.6.0", "@ethersproject/strings@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
   integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
@@ -380,7 +780,22 @@
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
+"@ethersproject/transactions@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+
+"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.6.0", "@ethersproject/transactions@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
@@ -395,6 +810,15 @@
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
 
+"@ethersproject/units@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
+  integrity sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/units@5.7.0", "@ethersproject/units@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
@@ -403,6 +827,27 @@
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/wallet@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.0.tgz#33d11a806d783864208f348709a5a3badac8e22a"
+  integrity sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/json-wallets" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
 
 "@ethersproject/wallet@5.7.0":
   version "5.7.0"
@@ -425,7 +870,18 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
-"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+"@ethersproject/web@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
+  dependencies:
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.6.0", "@ethersproject/web@^5.7.0":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
   integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
@@ -436,7 +892,18 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
+"@ethersproject/wordlists@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
+  integrity sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.6.0", "@ethersproject/wordlists@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
   integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
@@ -451,6 +918,68 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
+"@ganache/ethereum-address@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/ethereum-address/-/ethereum-address-0.1.4.tgz#0e6d66f4a24f64bf687cb3ff7358fb85b9d9005e"
+  integrity sha512-sTkU0M9z2nZUzDeHRzzGlW724xhMLXo2LeX1hixbnjHWY1Zg1hkqORywVfl+g5uOO8ht8T0v+34IxNxAhmWlbw==
+  dependencies:
+    "@ganache/utils" "0.1.4"
+
+"@ganache/ethereum-options@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/ethereum-options/-/ethereum-options-0.1.4.tgz#6a559abb44225e2b8741a8f78a19a46714a71cd6"
+  integrity sha512-i4l46taoK2yC41FPkcoDlEVoqHS52wcbHPqJtYETRWqpOaoj9hAg/EJIHLb1t6Nhva2CdTO84bG+qlzlTxjAHw==
+  dependencies:
+    "@ganache/ethereum-address" "0.1.4"
+    "@ganache/ethereum-utils" "0.1.4"
+    "@ganache/options" "0.1.4"
+    "@ganache/utils" "0.1.4"
+    bip39 "3.0.4"
+    seedrandom "3.0.5"
+
+"@ganache/ethereum-utils@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/ethereum-utils/-/ethereum-utils-0.1.4.tgz#fae4b5b9e642e751ff1fa0cd7316c92996317257"
+  integrity sha512-FKXF3zcdDrIoCqovJmHLKZLrJ43234Em2sde/3urUT/10gSgnwlpFmrv2LUMAmSbX3lgZhW/aSs8krGhDevDAg==
+  dependencies:
+    "@ethereumjs/common" "2.6.0"
+    "@ethereumjs/tx" "3.4.0"
+    "@ethereumjs/vm" "5.6.0"
+    "@ganache/ethereum-address" "0.1.4"
+    "@ganache/rlp" "0.1.4"
+    "@ganache/utils" "0.1.4"
+    emittery "0.10.0"
+    ethereumjs-abi "0.6.8"
+    ethereumjs-util "7.1.3"
+
+"@ganache/options@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/options/-/options-0.1.4.tgz#325b07e6de85094667aaaaf3d653e32404a04b78"
+  integrity sha512-zAe/craqNuPz512XQY33MOAG6Si1Xp0hCvfzkBfj2qkuPcbJCq6W/eQ5MB6SbXHrICsHrZOaelyqjuhSEmjXRw==
+  dependencies:
+    "@ganache/utils" "0.1.4"
+    bip39 "3.0.4"
+    seedrandom "3.0.5"
+
+"@ganache/rlp@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/rlp/-/rlp-0.1.4.tgz#f4043afda83e1a14a4f80607b103daf166a9b374"
+  integrity sha512-Do3D1H6JmhikB+6rHviGqkrNywou/liVeFiKIpOBLynIpvZhRCgn3SEDxyy/JovcaozTo/BynHumfs5R085MFQ==
+  dependencies:
+    "@ganache/utils" "0.1.4"
+    rlp "2.2.6"
+
+"@ganache/utils@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ganache/utils/-/utils-0.1.4.tgz#25d60d7689e3dda6a8a7ad70e3646f07c2c39a1f"
+  integrity sha512-oatUueU3XuXbUbUlkyxeLLH3LzFZ4y5aSkNbx6tjSIhVTPeh+AuBKYt4eQ73FFcTB3nj/gZoslgAh5CN7O369w==
+  dependencies:
+    emittery "0.10.0"
+    keccak "3.0.1"
+    seedrandom "3.0.5"
+  optionalDependencies:
+    "@trufflesuite/bigint-buffer" "1.1.9"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -904,6 +1433,43 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@resolver-engine/core@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"
+  integrity sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==
+  dependencies:
+    debug "^3.1.0"
+    is-url "^1.2.4"
+    request "^2.85.0"
+
+"@resolver-engine/fs@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@resolver-engine/fs/-/fs-0.3.3.tgz#fbf83fa0c4f60154a82c817d2fe3f3b0c049a973"
+  integrity sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==
+  dependencies:
+    "@resolver-engine/core" "^0.3.3"
+    debug "^3.1.0"
+
+"@resolver-engine/imports-fs@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@resolver-engine/imports-fs/-/imports-fs-0.3.3.tgz#4085db4b8d3c03feb7a425fbfcf5325c0d1e6c1b"
+  integrity sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==
+  dependencies:
+    "@resolver-engine/fs" "^0.3.3"
+    "@resolver-engine/imports" "^0.3.3"
+    debug "^3.1.0"
+
+"@resolver-engine/imports@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@resolver-engine/imports/-/imports-0.3.3.tgz#badfb513bb3ff3c1ee9fd56073e3144245588bcc"
+  integrity sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==
+  dependencies:
+    "@resolver-engine/core" "^0.3.3"
+    debug "^3.1.0"
+    hosted-git-info "^2.6.0"
+    path-browserify "^1.0.0"
+    url "^0.11.0"
+
 "@scure/base@~1.1.0", "@scure/base@~1.1.2", "@scure/base@~1.1.4":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.6.tgz#8ce5d304b436e4c84f896e0550c83e4d88cb917d"
@@ -1052,6 +1618,20 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@trufflesuite/bigint-buffer@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz#a1d9ca22d3cad1a138b78baaf15543637a3e1692"
+  integrity sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==
+  dependencies:
+    node-gyp-build "4.4.0"
+
+"@trufflesuite/bigint-buffer@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz#e2604d76e1e4747b74376d68f1312f9944d0d75d"
+  integrity sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==
+  dependencies:
+    node-gyp-build "4.3.0"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -1071,6 +1651,19 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@typechain/ethers-v5@^10.0.0":
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-10.2.1.tgz#50241e6957683281ecfa03fb5a6724d8a3ce2391"
+  integrity sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
+"@types/abstract-leveldown@*":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-7.2.5.tgz#db2cf364c159fb1f12be6cd3549f56387eaf8d73"
+  integrity sha512-/2B0nQF4UdupuxeKTJA2+Rj1D+uDemo6P4kMwKCpbfpnzeVaWSELTsAw4Lxn3VJD6APtRrZOCuYo+4nHUQfTfg==
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"
@@ -1111,7 +1704,21 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
   integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
-"@types/lru-cache@^5.1.0":
+"@types/level-errors@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/level-errors/-/level-errors-3.0.2.tgz#f33ec813c50780b547463da9ad8acac89ee457d9"
+  integrity sha512-gyZHbcQ2X5hNXf/9KS2qGEmgDe9EN2WDM3rJ5Ele467C0nA1sLhtmv1bZiPMDYfAYCfPWft0uQIaTvXbASSTRA==
+
+"@types/levelup@^4.3.0":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-4.3.3.tgz#4dc2b77db079b1cf855562ad52321aa4241b8ef4"
+  integrity sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==
+  dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/level-errors" "*"
+    "@types/node" "*"
+
+"@types/lru-cache@5.1.1", "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
@@ -1121,10 +1728,25 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mocha@>=9.1.0":
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
+
+"@types/node-fetch@^2.6.1":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
 
 "@types/node@*", "@types/node@>=18.0.0":
   version "20.12.7"
@@ -1132,6 +1754,11 @@
   integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
 "@types/node@18.15.13":
   version "18.15.13"
@@ -1145,12 +1772,22 @@
   dependencies:
     "@types/node" "*"
 
+"@types/prettier@^2.1.1":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
+  integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
+
 "@types/secp256k1@^4.0.1":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.6.tgz#d60ba2349a51c2cbc5e816dcd831a42029d376bf"
   integrity sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==
   dependencies:
     "@types/node" "*"
+
+"@types/seedrandom@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.1.tgz#1254750a4fec4aff2ebec088ccd0bb02e91fedb4"
+  integrity sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==
 
 "@uniswap/lib@4.0.1-alpha":
   version "4.0.1-alpha"
@@ -1181,6 +1818,40 @@ abitype@^0.9.8:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.10.tgz#fa6fa30a6465da98736f98b6c601a02ed49f6eec"
   integrity sha512-FIS7U4n7qwAT58KibwYig5iFG4K61rbhAqaQh/UWj8v1Y8mjX3F8TC9gd8cz9yT1TYel9f8nS5NO5kZp2RW0jQ==
+
+abstract-leveldown@^6.2.1:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz#d25221d1e6612f820c35963ba4bd739928f6026a"
+  integrity sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==
+  dependencies:
+    buffer "^5.5.0"
+    immediate "^3.2.3"
+    level-concat-iterator "~2.0.0"
+    level-supports "~1.0.0"
+    xtend "~4.0.0"
+
+abstract-leveldown@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz#08d19d4e26fb5be426f7a57004851b39e1795a2e"
+  integrity sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==
+  dependencies:
+    buffer "^6.0.3"
+    catering "^2.0.0"
+    is-buffer "^2.0.5"
+    level-concat-iterator "^3.0.0"
+    level-supports "^2.0.1"
+    queue-microtask "^1.2.3"
+
+abstract-leveldown@~6.2.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz#036543d87e3710f2528e47040bc3261b77a9a8eb"
+  integrity sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==
+  dependencies:
+    buffer "^5.5.0"
+    immediate "^3.2.3"
+    level-concat-iterator "~2.0.0"
+    level-supports "~1.0.0"
+    xtend "~4.0.0"
 
 acorn-walk@^8.1.1:
   version "8.3.2"
@@ -1222,7 +1893,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.12.6:
+ajv@^6.12.3, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1341,6 +2012,16 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1, array-back@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
+
 array-buffer-byte-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz#1e5583ec16763540a27ae52eed99ff899223568f"
@@ -1380,6 +2061,18 @@ arraybuffer.prototype.slice@^1.0.3:
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
+asn1@~0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
@@ -1395,6 +2088,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-eventemitter@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
+  integrity sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==
+  dependencies:
+    async "^2.4.0"
+
 async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
@@ -1407,6 +2107,13 @@ async@1.x:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
+async@^2.4.0:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1418,6 +2125,16 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
+
+aws4@^1.8.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.0.tgz#d9b802e9bb9c248d7be5f7f5ef178dc3684e9dcc"
+  integrity sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==
 
 axios@^1.4.0:
   version "1.7.2"
@@ -1449,20 +2166,42 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
+  dependencies:
+    tweetnacl "^0.14.3"
 
 bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
+bignumber.js@^9.0.0:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bip39@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
 
 blakejs@^1.1.0:
   version "1.2.1"
@@ -1474,7 +2213,7 @@ bn.js@4.11.6:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
-bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -1520,7 +2259,7 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.1.0:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
@@ -1573,6 +2312,13 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
 
+buffer-xor@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-2.0.2.tgz#34f7c64f04c777a1f8aac5e661273bb9dd320289"
+  integrity sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==
+  dependencies:
+    safe-buffer "^5.1.1"
+
 buffer@4.9.2:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
@@ -1581,6 +2327,29 @@ buffer@4.9.2:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.5.0, buffer@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
+bufferutil@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.5.tgz#da9ea8166911cc276bf677b8aed2d02d31f59028"
+  integrity sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -1625,6 +2394,16 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
+
+catering@^2.0.0, catering@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
+  integrity sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==
 
 cbor@^8.1.0:
   version "8.1.0"
@@ -1784,7 +2563,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.8:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1796,6 +2575,26 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
+command-line-args@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.3.tgz#428fa5acde6a838779dfa30e44686f4b6761d957"
+  integrity sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==
+  dependencies:
+    array-back "^4.0.2"
+    chalk "^2.4.2"
+    table-layout "^1.0.2"
+    typical "^5.2.0"
+
 commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
@@ -1805,6 +2604,11 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^8.1.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 compare-versions@^6.0.0:
   version "6.1.0"
@@ -1829,6 +2633,16 @@ cookie@^0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
+core-js-pure@^3.0.1:
+  version "3.37.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.37.1.tgz#2b4b34281f54db06c9a9a5bd60105046900553bd"
+  integrity sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==
+
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
 cosmiconfig@^8.0.0:
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
@@ -1838,6 +2652,11 @@ cosmiconfig@^8.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
+
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -1881,6 +2700,13 @@ cross-spawn@^7.0.0:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+  dependencies:
+    assert-plus "^1.0.0"
+
 data-view-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.1.tgz#8ea6326efec17a2e42620696e671d7d5a8bc66b2"
@@ -1920,6 +2746,27 @@ debug@4, debug@4.3.4, debug@^4.1.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.3.1, debug@^4.3.3, debug@^4.3.4:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
@@ -1946,7 +2793,7 @@ deep-eql@^4.1.3:
   dependencies:
     type-detect "^4.0.0"
 
-deep-extend@^0.6.0:
+deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
@@ -1960,6 +2807,14 @@ defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
+
+deferred-leveldown@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz#27a997ad95408b61161aa69bd489b86c71b78058"
+  integrity sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==
+  dependencies:
+    abstract-leveldown "~6.2.1"
+    inherits "^2.0.3"
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
@@ -2023,6 +2878,14 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
 elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
@@ -2049,6 +2912,11 @@ elliptic@^6.5.2, elliptic@^6.5.4:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+emittery@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.0.tgz#bb373c660a9d421bb44706ec4967ed50c02a8026"
+  integrity sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -2058,6 +2926,16 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+encoding-down@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/encoding-down/-/encoding-down-6.3.0.tgz#b1c4eb0e1728c146ecaef8e32963c549e76d082b"
+  integrity sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==
+  dependencies:
+    abstract-leveldown "^6.2.1"
+    inherits "^2.0.3"
+    level-codec "^9.0.0"
+    level-errors "^2.0.0"
 
 enquirer@^2.3.0:
   version "2.4.1"
@@ -2071,6 +2949,13 @@ env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+errno@~0.1.1:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"
+  integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
+  dependencies:
+    prr "~1.0.1"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2270,13 +3155,36 @@ ethereum-cryptography@^2.0.0, ethereum-cryptography@^2.1.2, ethereum-cryptograph
     "@scure/bip32" "1.3.3"
     "@scure/bip39" "1.2.2"
 
-ethereumjs-abi@^0.6.8:
+ethereum-waffle@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-4.0.10.tgz#f1ef1564c0155236f1a66c6eae362a5d67c9f64c"
+  integrity sha512-iw9z1otq7qNkGDNcMoeNeLIATF9yKl1M8AIeu42ElfNBplq0e+5PeasQmm8ybY/elkZ1XyRO0JBQxQdVRb8bqQ==
+  dependencies:
+    "@ethereum-waffle/chai" "4.0.10"
+    "@ethereum-waffle/compiler" "4.0.3"
+    "@ethereum-waffle/mock-contract" "4.0.4"
+    "@ethereum-waffle/provider" "4.0.5"
+    solc "0.8.15"
+    typechain "^8.0.0"
+
+ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
   integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
   dependencies:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
+
+ethereumjs-util@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz#b55d7b64dde3e3e45749e4c41288238edec32d23"
+  integrity sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.2.4"
 
 ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
   version "6.2.1"
@@ -2291,7 +3199,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
+ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.3, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
   integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
@@ -2301,6 +3209,42 @@ ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
     create-hash "^1.1.2"
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
+
+ethers@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.2.tgz#e75bac7f038c5e0fdde667dba62fc223924143a2"
+  integrity sha512-EzGCbns24/Yluu7+ToWnMca3SXJ1Jk1BvWB7CCmVNxyOeM4LLvw2OLuIHhlkhQk1dtOcj9UMsdkxUh8RiG1dxQ==
+  dependencies:
+    "@ethersproject/abi" "5.6.0"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.1"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.1"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.2"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.0"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
 
 ethers@^5.7.2:
   version "5.7.2"
@@ -2375,6 +3319,21 @@ evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
+
 fast-base64-decode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
@@ -2425,6 +3384,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -2465,6 +3431,11 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
 form-data-encoder@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
@@ -2477,6 +3448,15 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fp-ts@1.19.3:
@@ -2509,7 +3489,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -2552,10 +3532,32 @@ function.prototype.name@^1.1.6:
     es-abstract "^1.22.1"
     functions-have-names "^1.2.3"
 
+functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+ganache@7.4.3:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.4.3.tgz#e995f1250697264efbb34d4241c374a2b0271415"
+  integrity sha512-RpEDUiCkqbouyE7+NMXG26ynZ+7sGiODU84Kz+FVoXUnQ4qQM4M8wif3Y4qUCt+D/eM1RVeGq0my62FPD6Y1KA==
+  dependencies:
+    "@trufflesuite/bigint-buffer" "1.1.10"
+    "@types/bn.js" "^5.1.0"
+    "@types/lru-cache" "5.1.1"
+    "@types/seedrandom" "3.0.1"
+    emittery "0.10.0"
+    keccak "3.0.2"
+    leveldown "6.1.0"
+    secp256k1 "4.0.3"
+  optionalDependencies:
+    bufferutil "4.0.5"
+    utf-8-validate "5.0.7"
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -2592,6 +3594,13 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
+  dependencies:
+    assert-plus "^1.0.0"
+
 ghost-testrpc@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz#c4de9557b1d1ae7b2d20bbe474a91378ca90ce92"
@@ -2606,6 +3615,18 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@7.2.0:
   version "7.2.0"
@@ -2747,6 +3768,19 @@ handlebars@^4.0.1:
     wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
+
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
 
 hardhat-contract-sizer@^2.10.0:
   version "2.10.0"
@@ -2914,6 +3948,11 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hosted-git-info@^2.6.0:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
 http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
@@ -2929,6 +3968,15 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
 
 http2-wrapper@^2.1.10:
   version "2.2.1"
@@ -2953,7 +4001,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -2962,6 +4010,16 @@ ignore@^5.1.1, ignore@^5.2.4:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+
+immediate@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
+  integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
+
+immediate@~3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
+  integrity sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==
 
 immer@10.0.2:
   version "10.0.2"
@@ -2994,7 +4052,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3059,6 +4117,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
@@ -3166,10 +4229,20 @@ is-typed-array@^1.1.13:
   dependencies:
     which-typed-array "^1.1.14"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -3211,6 +4284,11 @@ isows@1.0.4:
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.4.tgz#810cd0d90cc4995c26395d2aa4cfa4037ebdf061"
   integrity sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==
 
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
+
 jackspeak@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
@@ -3225,7 +4303,7 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
-js-sha3@0.8.0:
+js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -3250,6 +4328,18 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -3270,7 +4360,12 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-stringify-safe@^5.0.1:
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -3302,6 +4397,33 @@ jsonschema@^1.2.4, jsonschema@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
+
+jsprim@^1.2.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
+    verror "1.10.0"
+
+keccak@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
+  integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+
+keccak@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
+  integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+    readable-stream "^3.6.0"
 
 keccak@^3.0.0, keccak@^3.0.2:
   version "3.0.4"
@@ -3343,6 +4465,98 @@ latest-version@^7.0.0:
   dependencies:
     package-json "^8.1.0"
 
+level-codec@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-9.0.2.tgz#fd60df8c64786a80d44e63423096ffead63d8cbc"
+  integrity sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==
+  dependencies:
+    buffer "^5.6.0"
+
+level-concat-iterator@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz#5235b1f744bc34847ed65a50548aa88d22e881cf"
+  integrity sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==
+  dependencies:
+    catering "^2.1.0"
+
+level-concat-iterator@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz#1d1009cf108340252cb38c51f9727311193e6263"
+  integrity sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==
+
+level-errors@^2.0.0, level-errors@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-2.0.1.tgz#2132a677bf4e679ce029f517c2f17432800c05c8"
+  integrity sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==
+  dependencies:
+    errno "~0.1.1"
+
+level-iterator-stream@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz#7ceba69b713b0d7e22fcc0d1f128ccdc8a24f79c"
+  integrity sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+    xtend "^4.0.2"
+
+level-mem@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/level-mem/-/level-mem-5.0.1.tgz#c345126b74f5b8aa376dc77d36813a177ef8251d"
+  integrity sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==
+  dependencies:
+    level-packager "^5.0.3"
+    memdown "^5.0.0"
+
+level-packager@^5.0.3:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/level-packager/-/level-packager-5.1.1.tgz#323ec842d6babe7336f70299c14df2e329c18939"
+  integrity sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==
+  dependencies:
+    encoding-down "^6.3.0"
+    levelup "^4.3.2"
+
+level-supports@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-2.1.0.tgz#9af908d853597ecd592293b2fad124375be79c5f"
+  integrity sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==
+
+level-supports@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-1.0.1.tgz#2f530a596834c7301622521988e2c36bb77d122d"
+  integrity sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==
+  dependencies:
+    xtend "^4.0.2"
+
+level-ws@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/level-ws/-/level-ws-2.0.0.tgz#207a07bcd0164a0ec5d62c304b4615c54436d339"
+  integrity sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^3.1.0"
+    xtend "^4.0.1"
+
+leveldown@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-6.1.0.tgz#7ab1297706f70c657d1a72b31b40323aa612b9ee"
+  integrity sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==
+  dependencies:
+    abstract-leveldown "^7.2.0"
+    napi-macros "~2.0.0"
+    node-gyp-build "^4.3.0"
+
+levelup@^4.3.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/levelup/-/levelup-4.4.0.tgz#f89da3a228c38deb49c48f88a70fb71f01cafed6"
+  integrity sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==
+  dependencies:
+    deferred-leveldown "~5.3.0"
+    level-errors "~2.0.0"
+    level-iterator-stream "~4.0.0"
+    level-supports "~1.0.0"
+    xtend "~4.0.0"
+
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -3371,6 +4585,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -3391,7 +4610,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.19, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3421,6 +4640,13 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3432,6 +4658,11 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
+ltgt@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
+  integrity sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -3445,6 +4676,11 @@ markdown-table@2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
+mcl-wasm@^0.7.1:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.9.tgz#c1588ce90042a8700c3b60e40efb339fc07ab87f"
+  integrity sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -3453,6 +4689,18 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+memdown@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/memdown/-/memdown-5.1.0.tgz#608e91a9f10f37f5b5fe767667a8674129a833cb"
+  integrity sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==
+  dependencies:
+    abstract-leveldown "~6.2.1"
+    functional-red-black-tree "~1.0.1"
+    immediate "~3.2.3"
+    inherits "~2.0.1"
+    ltgt "~2.2.0"
+    safe-buffer "~5.2.0"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -3463,6 +4711,18 @@ merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+merkle-patricia-tree@^4.2.2, merkle-patricia-tree@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.2.4.tgz#ff988d045e2bf3dfa2239f7fabe2d59618d57413"
+  integrity sha512-eHbf/BG6eGNsqqfbLED9rIqbsF4+sykEaBn6OLNs71tjclbMcMOk1tEPmJKcNcNCLkvbpY/lwyOlizWsqPNo8w==
+  dependencies:
+    "@types/levelup" "^4.3.0"
+    ethereumjs-util "^7.1.4"
+    level-mem "^5.0.1"
+    level-ws "^2.0.0"
+    readable-stream "^3.6.0"
+    semaphore-async-await "^1.5.1"
 
 micro-ftch@^0.3.1:
   version "0.3.1"
@@ -3477,12 +4737,20 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+miller-rabin@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
+  dependencies:
+    bn.js "^4.0.0"
+    brorand "^1.0.1"
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -3547,12 +4815,17 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.7:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.1.tgz#f7f85aff59aa22f110b20e27692465cf3bf89481"
   integrity sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==
 
-mkdirp@0.5.x:
+mkdirp@0.5.x, mkdirp@^0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mnemonist@^0.38.0:
   version "0.38.5"
@@ -3587,15 +4860,25 @@ mocha@^10.0.0, mocha@^10.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+napi-macros@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.0.0.tgz#2b6bae421e7b96eb687aa6c77a7858640670001b"
+  integrity sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==
 
 ndjson@2.0.0:
   version "2.0.0"
@@ -3625,17 +4908,32 @@ node-emoji@^1.10.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
+node-gyp-build@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+
+node-gyp-build@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
+  integrity sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==
+
 node-gyp-build@^4.2.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.0.tgz#3fee9c1731df4581a3f9ead74664369ff00d26dd"
   integrity sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==
+
+node-gyp-build@^4.3.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
+  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
 
 nofilter@^3.1.0:
   version "3.1.0"
@@ -3666,6 +4964,11 @@ number-to-bn@1.7.0:
   dependencies:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-inspect@^1.13.1:
   version "1.13.1"
@@ -3793,6 +5096,11 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+path-browserify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -3836,7 +5144,7 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-pbkdf2@^3.0.17:
+pbkdf2@^3.0.17, pbkdf2@^3.0.9:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
@@ -3846,6 +5154,11 @@ pbkdf2@^3.0.17:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
 picocolors@^1.0.0:
   version "1.0.1"
@@ -3877,7 +5190,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-prettier@^2.8.3:
+prettier@^2.3.1, prettier@^2.8.3:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
@@ -3909,12 +5222,39 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-punycode@^2.1.0:
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+  integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
+
+psl@^1.1.28:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
+
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-queue-microtask@^1.2.2:
+qs@^6.12.3:
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.12.3.tgz#e43ce03c8521b9c7fd7f1f13e514e5ca37727754"
+  integrity sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==
+  dependencies:
+    side-channel "^1.0.6"
+
+qs@~6.5.2:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+
+queue-microtask@^1.2.2, queue-microtask@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
@@ -3924,7 +5264,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-randombytes@^2.1.0:
+randombytes@^2.0.1, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -3951,7 +5291,7 @@ rc@1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.0, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -3981,6 +5321,11 @@ recursive-readdir@^2.2.2:
   dependencies:
     minimatch "^3.0.5"
 
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
+
 regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
@@ -4009,6 +5354,32 @@ repeat-string@^1.0.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
+
+request@^2.85.0:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4088,6 +5459,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rlp@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
+  integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
+  dependencies:
+    bn.js "^4.11.1"
+
 rlp@^2.2.3, rlp@^2.2.4:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.7.tgz#33f31c4afac81124ac4b283e2bd4d9720b30beaf"
@@ -4101,6 +5479,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rustbn.js@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
+  integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
 safe-array-concat@^1.1.2:
   version "1.1.2"
@@ -4126,7 +5509,7 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4156,7 +5539,7 @@ scrypt-js@3.0.1, scrypt-js@^3.0.0:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
-secp256k1@^4.0.1:
+secp256k1@4.0.3, secp256k1@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
   integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
@@ -4164,6 +5547,16 @@ secp256k1@^4.0.1:
     elliptic "^6.5.4"
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
+
+seedrandom@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
+semaphore-async-await@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz#857bef5e3644601ca4b9570b87e9df5ca12974fa"
+  integrity sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==
 
 semver@^5.5.0:
   version "5.7.2"
@@ -4263,7 +5656,7 @@ shelljs@^0.8.3:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-side-channel@^1.0.4:
+side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
   integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
@@ -4314,6 +5707,19 @@ solc@0.7.3:
     js-sha3 "0.8.0"
     memorystream "^0.3.1"
     require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
+solc@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.15.tgz#d274dca4d5a8b7d3c9295d4cbdc9291ee1c52152"
+  integrity sha512-Riv0GNHNk/SddN/JyEuFKwbcWcEeho15iyupTSHw5Np6WuXA5D8kEHbyzDHi6sqmvLzu2l+8b1YmL8Ytple+8w==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "^8.1.0"
+    follow-redirects "^1.12.1"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
     semver "^5.5.0"
     tmp "0.0.33"
 
@@ -4407,6 +5813,21 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+sshpk@^1.7.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
+  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
 stacktrace-parser@^0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
@@ -4418,6 +5839,11 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+string-format@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
+  integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
@@ -4536,6 +5962,16 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+table-layout@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 table@^6.8.0, table@^6.8.1:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.2.tgz#c5504ccf201213fa227248bdc8c5569716ac6c58"
@@ -4578,10 +6014,33 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-command-line-args@^2.2.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz#e64456b580d1d4f6d948824c274cf6fa5f45f7f0"
+  integrity sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==
+  dependencies:
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-usage "^6.1.0"
+    string-format "^2.0.0"
+
+ts-essentials@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-node@>=8.0.0:
   version "10.9.2"
@@ -4622,10 +6081,22 @@ tsort@0.0.1:
   resolved "https://registry.yarnpkg.com/tsort/-/tsort-0.0.1.tgz#e2280f5e817f8bf4275657fd0f9aebd44f5a2786"
   integrity sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 tweetnacl-util@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
   integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 tweetnacl@^1.0.3:
   version "1.0.3"
@@ -4658,6 +6129,22 @@ type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+
+typechain@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-8.3.2.tgz#1090dd8d9c57b6ef2aed3640a516bdbf01b00d73"
+  integrity sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==
+  dependencies:
+    "@types/prettier" "^2.1.1"
+    debug "^4.3.1"
+    fs-extra "^7.0.0"
+    glob "7.1.7"
+    js-sha3 "^0.8.0"
+    lodash "^4.17.15"
+    mkdirp "^1.0.4"
+    prettier "^2.3.1"
+    ts-command-line-args "^2.2.0"
+    ts-essentials "^7.0.1"
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -4707,6 +6194,16 @@ typescript@~5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -4767,6 +6264,21 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url@^0.11.0:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.4.tgz#adca77b3562d56b72746e76b330b7f27b6721f3c"
+  integrity sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==
+  dependencies:
+    punycode "^1.4.1"
+    qs "^6.12.3"
+
+utf-8-validate@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.7.tgz#c15a19a6af1f7ad9ec7ddc425747ca28c3644922"
+  integrity sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 utf8@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
@@ -4777,6 +6289,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -4786,6 +6303,15 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 viem@2.7.14:
   version "2.7.14"
@@ -4895,6 +6421,14 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
+
 workerpool@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
@@ -4943,10 +6477,20 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Changes

List of Changes:

- [x] Deploy pair of RA:CT on every new issuance
- [x] Fetch and calculate ratio using uni v2 pool pair balance
- [x] Actually Add Liquidity to uni v2 pair when depositing to LV
- [x] AMM LV LP liquidation
- [x] Adjust test helpers
- [x] Adjust previous test

# Notes
- Due to uni v2 locking liquidity(1e-15 lp) every first deposit, the amount received by user would be slightly less on Lv Expired and Early withdrawals by 0.0000000000000001 ETH (approx 1e-15)
- Test now support comparison between bigNumber using ethers and ethereum-waffle
- Added explicit types to Tests