### PR TITLE
Added fees updation mechanism

### DIFF
--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -15,6 +15,8 @@ contract CorkConfig is AccessControl, Pausable {
     error CallerNotManager();
     error InvalidAddress();
 
+    /// @notice Emitted when a moduleCore variable set 
+    /// @param moduleCore Address of Modulecore contract
     event ModuleCoreSet(address moduleCore);
 
     modifier onlyManager() {
@@ -62,6 +64,26 @@ contract CorkConfig is AccessControl, Pausable {
         onlyManager
     {
         moduleCore.issueNewDs(id, expiry, exchangeRates, repurchaseFeePrecentage);
+    }
+
+    /**
+     * @dev Updates fee rates for psm repurchase
+     */
+    function updateRepurchaseFeeRate(
+        Id id,
+        uint256 newRepurchaseFeePrecentage        
+    ) external onlyManager {
+        moduleCore.updateRepurchaseFeeRate(id, newRepurchaseFeePrecentage);
+    }
+
+    /**
+     * @dev Updates earlyFeeRedemption rates 
+     */
+    function updateEarlyRedemptionFeeRate(
+        Id id,
+        uint256 newEarlyRedemptionFeeRate        
+    ) external onlyManager {
+        moduleCore.updateEarlyRedemptionFeeRate(id, newEarlyRedemptionFeeRate);
     }
 
     /**

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -100,6 +100,26 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         emit Issued(id, idx, expiry, _ds, _ct);
     }
 
+    function updateRepurchaseFeeRate(
+        Id id,
+        uint256 newRepurchaseFeePrecentage        
+    ) external onlyConfig {
+        State storage state = states[id];
+        state.psm.repurchaseFeePrecentage = newRepurchaseFeePrecentage;
+
+        emit RepurchaseFeeRateUpdated(id, newRepurchaseFeePrecentage);
+    }
+
+    function updateEarlyRedemptionFeeRate(
+        Id id,
+        uint256 newEarlyRedemptionFeeRate        
+    ) external onlyConfig {
+        State storage state = states[id];
+        VaultConfigLibrary.updateFee(state.vault.config, newEarlyRedemptionFeeRate);
+
+        emit RepurchaseFeeRateUpdated(id, newEarlyRedemptionFeeRate);
+    }
+
     function lastDsId(Id id) external view override returns (uint256 dsId) {
         return states[id].globalAssetIdx;
     }

--- a/contracts/interfaces/IRepurchase.sol
+++ b/contracts/interfaces/IRepurchase.sol
@@ -25,6 +25,14 @@ interface IRepurchase {
         uint256 exchangeRates
     );
 
+    /// @notice Emitted when a repurchaseFee is updated for a given PSM
+    /// @param Id The PSM id
+    /// @param repurchaseFeeRate The new repurchaseFee rate
+    event RepurchaseFeeRateUpdated(
+        Id indexed Id,
+        uint256 indexed repurchaseFeeRate
+    );
+
     /**
      * @notice thrown when the user tries to repurchase more than the available PA + DSliquidity
      * @param available the amount of available PA + DS

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -67,6 +67,14 @@ interface IVault {
         uint256 amount
     );
 
+    /// @notice Emitted when a early redemption fee is updated for a given Vault
+    /// @param Id The State id
+    /// @param newEarlyRedemptionFee The new early redemption rate
+    event EarlyRedemptionFeeUpdated(
+        Id indexed Id,
+        uint256 indexed newEarlyRedemptionFee
+    );
+
     /**
      * @notice Deposit a wrapped asset into a given vault
      * @param id The Module id that is used to reference both psm and lv of a given pair

--- a/contracts/interfaces/Init.sol
+++ b/contracts/interfaces/Init.sol
@@ -17,4 +17,14 @@ interface Initialize {
         uint256 exchangeRates,
         uint256 repurchaseFeePrecentage
     ) external;
+
+    function updateRepurchaseFeeRate(
+        Id id,
+        uint256 newRepurchaseFeePrecentage        
+    ) external;
+
+    function updateEarlyRedemptionFeeRate(
+        Id id,
+        uint256 newEarlyRedemptionFeeRate        
+    ) external;
 }

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -21,7 +21,6 @@ library VaultLibrary {
     using PsmLibrary for State;
     using RedemptionAssetManagerLibrary for PsmRedemptionAssetManager;
     using BitMaps for BitMaps.BitMap;
-    using VaultLibrary for VaultState;
     using DepegSwapLibrary for DepegSwap;
     using VaultPoolLibrary for VaultPool;
 


### PR DESCRIPTION
# Changes

List of Changes:
 -  Added function for updating PSM Repurchase fee rates
 -  Added function for updating LV EarlyRedemption fee rates

# Notes
 - Now admins with MANAGER role in config contract can call updateRepurchaseFeeRate function to update PSM Repurchase fee rates and can call updateEarlyRedemptionFeeRate function to update LV early redemption fee rates


