### PR TITLE
Feat/permit support

### DIFF
--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -9,6 +9,7 @@ import "../libraries/PsmLib.sol";
 import "../interfaces/uniswap-v2/factory.sol";
 import "./flash-swaps/RouterState.sol";
 import "../interfaces/uniswap-v2/RouterV2.sol";
+import "../libraries/MutexLock.sol";
 
 abstract contract ModuleState is ICommon {
     using PsmLibrary for State;
@@ -108,5 +109,13 @@ abstract contract ModuleState is ICommon {
         if (getSwapAssetFactory().isDeployed(asset) == false) {
             revert InvalidAsset(asset);
         }
+    }
+
+    /// @notice This will revert if the contract is locked
+    modifier nonReentrant() {
+        if (MutexLock.isLocked()) revert StateLocked();
+        MutexLock.lock();
+        _;
+        MutexLock.unlock();
     }
 }

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -117,7 +117,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         uint256 amount,
         bytes memory rawDsPermitSig,
         uint256 deadline
-    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+    ) external override nonReentrant onlyInitialized(id) PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
 
         (uint256 received, uint256 _exchangeRate) = state.redeemWithDs(
@@ -142,7 +142,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         Id id,
         uint256 dsId,
         uint256 amount
-    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+    ) external override nonReentrant onlyInitialized(id) PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
 
         (uint256 received, uint256 _exchangeRate) = state.redeemWithDs(
@@ -190,7 +190,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         uint256 amount,
         bytes memory rawCtPermitSig,
         uint256 deadline
-    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+    ) external override nonReentrant onlyInitialized(id) PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
 
         (uint256 accruedPa, uint256 accruedRa) = state.redeemWithCt(
@@ -208,7 +208,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         Id id,
         uint256 dsId,
         uint256 amount
-    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+    ) external override nonReentrant onlyInitialized(id) PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
 
         (uint256 accruedPa, uint256 accruedRa) = state.redeemWithCt(
@@ -248,7 +248,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         uint256 dsDeadline,
         bytes memory rawCtPermitSig,
         uint256 ctDeadline
-    ) external override PSMWithdrawalNotPaused(id) {
+    ) external override nonReentrant PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 ra, uint256 dsId, uint256 rates) = state.redeemRaWithCtDs(
             _msgSender(),
@@ -262,7 +262,10 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         emit Cancelled(id, dsId, _msgSender(), ra, amount, rates);
     }
 
-    function redeemRaWithCtDs(Id id, uint256 amount) external override PSMWithdrawalNotPaused(id) {
+    function redeemRaWithCtDs(
+        Id id, 
+        uint256 amount
+    ) external override nonReentrant PSMWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 ra, uint256 dsId, uint256 rates) = state.redeemRaWithCtDs(
             _msgSender(),

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -138,6 +138,29 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         );
     }
 
+    function redeemRaWithDs(
+        Id id,
+        uint256 dsId,
+        uint256 amount
+    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+        State storage state = states[id];
+
+        (uint256 received, uint256 _exchangeRate) = state.redeemWithDs(
+            _msgSender(),
+            amount,
+            dsId
+        );
+
+        emit DsRedeemed(
+            id,
+            dsId,
+            _msgSender(),
+            amount,
+            received,
+            _exchangeRate
+        );
+    }
+
     function exchangeRate(
         Id id
     ) external view override returns (uint256 rates) {
@@ -181,6 +204,22 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         emit CtRedeemed(id, dsId, _msgSender(), amount, accruedPa, accruedRa);
     }
 
+    function redeemWithCT(
+        Id id,
+        uint256 dsId,
+        uint256 amount
+    ) external override onlyInitialized(id) PSMWithdrawalNotPaused(id) {
+        State storage state = states[id];
+
+        (uint256 accruedPa, uint256 accruedRa) = state.redeemWithCt(
+            _msgSender(),
+            amount,
+            dsId
+        );
+
+        emit CtRedeemed(id, dsId, _msgSender(), amount, accruedPa, accruedRa);
+    }
+
     function previewRedeemWithCt(
         Id id,
         uint256 dsId,
@@ -200,6 +239,27 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     function valueLocked(Id id) external view override returns (uint256) {
         State storage state = states[id];
         return state.valueLocked();
+    }
+
+    function redeemRaWithCtDs(
+        Id id,
+        uint256 amount,
+        bytes memory rawDsPermitSig,
+        uint256 dsDeadline,
+        bytes memory rawCtPermitSig,
+        uint256 ctDeadline
+    ) external override PSMWithdrawalNotPaused(id) {
+        State storage state = states[id];
+        (uint256 ra, uint256 dsId, uint256 rates) = state.redeemRaWithCtDs(
+            _msgSender(),
+            amount,
+            rawDsPermitSig,
+            dsDeadline,
+            rawCtPermitSig,
+            ctDeadline
+        );
+
+        emit Cancelled(id, dsId, _msgSender(), ra, amount, rates);
     }
 
     function redeemRaWithCtDs(Id id, uint256 amount) external override PSMWithdrawalNotPaused(id) {

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -46,6 +46,17 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         lv = VaultLibrary.previewDeposit(amount);
     }
 
+    function requestRedemption(
+        Id id, 
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external override LVWithdrawalNotPaused(id) {
+        State storage state = states[id];
+        state.requestRedemption(_msgSender(), amount, rawLvPermitSig, deadline);
+        emit RedemptionRequested(id, _msgSender(), amount);
+    }
+
     function requestRedemption(Id id, uint256 amount) external override LVWithdrawalNotPaused(id) {
         State storage state = states[id];
         state.requestRedemption(_msgSender(), amount);
@@ -60,6 +71,26 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         State storage state = states[id];
         state.transferRedemptionRights(_msgSender(), to, amount);
         emit RedemptionRightTransferred(id, _msgSender(), to, amount);
+    }
+
+    function redeemExpiredLv(
+        Id id,
+        address receiver,
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external override LVWithdrawalNotPaused(id) {
+        State storage state = states[id];
+        (uint256 attributedRa, uint256 attributedPa) = state.redeemExpired(
+            _msgSender(),
+            receiver,
+            amount,
+            getAmmRouter(),
+            getRouterCore(),
+            rawLvPermitSig,
+            deadline
+        );
+        emit LvRedeemExpired(id, receiver, attributedRa, attributedPa);
     }
 
     function redeemExpiredLv(
@@ -95,6 +126,35 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         State storage state = states[id];
         (attributedRa, attributedPa, approvedAmount) = state
             .previewRedeemExpired(amount, _msgSender(), getRouterCore());
+    }
+
+    function redeemEarlyLv(
+        Id id,
+        address receiver,
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external override LVWithdrawalNotPaused(id) {
+        State storage state = states[id];
+        (uint256 received, uint256 fee, uint256 feePrecentage) = state
+            .redeemEarly(
+                _msgSender(),
+                receiver,
+                amount,
+                getRouterCore(),
+                getAmmRouter(),
+                rawLvPermitSig,
+                deadline        
+            );
+
+        emit LvRedeemEarly(
+            id,
+            _msgSender(),
+            receiver,
+            received,
+            fee,
+            feePrecentage
+        );
     }
 
     function redeemEarlyLv(

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -79,7 +79,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         uint256 amount,
         bytes memory rawLvPermitSig,
         uint256 deadline
-    ) external override LVWithdrawalNotPaused(id) {
+    ) external override nonReentrant LVWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 attributedRa, uint256 attributedPa) = state.redeemExpired(
             _msgSender(),
@@ -97,7 +97,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         Id id,
         address receiver,
         uint256 amount
-    ) external override LVWithdrawalNotPaused(id) {
+    ) external override nonReentrant LVWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 attributedRa, uint256 attributedPa) = state.redeemExpired(
             _msgSender(),
@@ -134,7 +134,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         uint256 amount,
         bytes memory rawLvPermitSig,
         uint256 deadline
-    ) external override LVWithdrawalNotPaused(id) {
+    ) external override nonReentrant LVWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 received, uint256 fee, uint256 feePrecentage) = state
             .redeemEarly(
@@ -161,7 +161,7 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         Id id,
         address receiver,
         uint256 amount
-    ) external override LVWithdrawalNotPaused(id) {
+    ) external override nonReentrant LVWithdrawalNotPaused(id) {
         State storage state = states[id];
         (uint256 received, uint256 fee, uint256 feePrecentage) = state
             .redeemEarly(

--- a/contracts/interfaces/ICommon.sol
+++ b/contracts/interfaces/ICommon.sol
@@ -28,6 +28,9 @@ interface ICommon {
     /// @notice LV Withdrawal is paused, i.e thrown when withdrawal is paused for LV
     error LVWithdrawalPaused();
 
+    /// @notice When transaction is mutex locked for ensuring non-reentrancy 
+    error StateLocked();
+
     /// @notice Emitted when a new LV and PSM is initialized with a given pair
     /// @param id The PSM id
     /// @param pa The address of the pegged asset

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -107,6 +107,12 @@ interface IPSMcore is IRepurchase {
         uint256 deadline
     ) external;
 
+    function redeemRaWithDs(
+        Id id,
+        uint256 dsId,
+        uint256 amount
+    ) external;
+
     function previewRedeemRaWithDs(
         Id id,
         uint256 dsId,
@@ -121,11 +127,26 @@ interface IPSMcore is IRepurchase {
         uint256 deadline
     ) external;
 
+    function redeemWithCT(
+        Id id,
+        uint256 dsId,
+        uint256 amount
+    ) external;
+
     function previewRedeemWithCt(
         Id id,
         uint256 dsId,
         uint256 amount
     ) external view returns (uint256 paReceived, uint256 raReceived);
+
+    function redeemRaWithCtDs(
+        Id id,
+        uint256 amount,
+        bytes memory rawDsPermitSig,
+        uint256 dsDeadline,
+        bytes memory rawCtPermitSig,
+        uint256 ctDeadline
+    ) external;
 
     function redeemRaWithCtDs(Id id, uint256 amount) external;
 

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -94,6 +94,19 @@ interface IVault {
     /**
      * @notice Request redemption of a given vault at expiry
      * @param id The Module id that is used to reference both psm and lv of a given pair
+     * @param rawLvPermitSig  The signature for Lv transfer permitted by user
+     * @param deadline  The deadline timestamp os signature expiry
+     */
+    function requestRedemption(
+        Id id, 
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external;
+
+    /**
+     * @notice Request redemption of a given vault at expiry
+     * @param id The Module id that is used to reference both psm and lv of a given pair
      */
     function requestRedemption(Id id, uint256 amount) external;
 
@@ -107,6 +120,22 @@ interface IVault {
         Id id,
         address to,
         uint256 amount
+    ) external;
+
+    /**
+     * @notice Redeem expired lv, when there's no active DS issuance, there's no cap on the amount of lv that can be redeemed.
+     * @param id The Module id that is used to reference both psm and lv of a given pair
+     * @param receiver  The address of the receiver
+     * @param amount The amount of the asset to be redeemed
+     * @param rawLvPermitSig  The signature for Lv transfer permitted by user
+     * @param deadline  The deadline timestamp os signature expiry
+     */
+    function redeemExpiredLv(
+        Id id,
+        address receiver,
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
     ) external;
 
     /**
@@ -137,6 +166,20 @@ interface IVault {
             uint256 attributedPa,
             uint256 approvedAmount
         );
+
+    /**
+     * @notice Redeem lv before expiry
+     * @param id The Module id that is used to reference both psm and lv of a given pair
+     * @param receiver The address of the receiver
+     * @param amount The amount of the asset to be redeemed
+     */
+    function redeemEarlyLv(
+        Id id,
+        address receiver,
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external;
 
     /**
      * @notice Redeem lv before expiry

--- a/contracts/libraries/MutexLock.sol
+++ b/contracts/libraries/MutexLock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+library MutexLock {
+    // The slot holding the locked state, transiently. bytes32(uint256(keccak256("Locked")) - 1)
+    bytes32 internal constant IS_LOCKED_SLOT = 0x10bc01d611f2c803e55ff98d999836f196afae7cf91f96f3b6f511e56ba84973;
+
+    function unlock() internal {
+        assembly ("memory-safe") {
+            // unlock
+            tstore(IS_LOCKED_SLOT, false)
+        }
+    }
+
+    function lock() internal {
+        assembly ("memory-safe") {
+            tstore(IS_LOCKED_SLOT, true)
+        }
+    }
+
+    function isLocked() internal view returns (bool unlocked) {
+        assembly ("memory-safe") {
+            unlocked := tload(IS_LOCKED_SLOT)
+        }
+    }
+}

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -262,15 +262,42 @@ library VaultLibrary {
         lvReceived = amount;
     }
 
+    function _requestRedemption(
+        State storage self,
+        address owner,
+        uint256 amount
+    ) internal {
+        self.vault.pool.withdrawEligible[owner] += amount;
+        self.vault.pool.withdrawalPool.atrributedLv += amount;
+        self.vault.lv.lockFrom(amount, owner);
+    }
+
+    function requestRedemption(
+        State storage self,
+        address owner,
+        uint256 amount,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external {
+        safeBeforeExpired(self);
+        DepegSwapLibrary.permit(
+            self.vault.lv._address,
+            rawLvPermitSig,
+            owner,
+            self.vault.lv._address,
+            amount,
+            deadline
+        );
+        _requestRedemption(self, owner, amount);
+    }
+
     function requestRedemption(
         State storage self,
         address owner,
         uint256 amount
     ) external {
         safeBeforeExpired(self);
-        self.vault.pool.withdrawEligible[owner] += amount;
-        self.vault.pool.withdrawalPool.atrributedLv += amount;
-        self.vault.lv.lockFrom(amount, owner);
+        _requestRedemption(self, owner, amount);
     }
 
     function lvLockedFor(
@@ -682,17 +709,15 @@ library VaultLibrary {
         ra = MinimalUniswapV2Library.getAmountOut(ct, ctReserve, raReserve);
     }
 
-    function redeemExpired(
+    function _redeemExpired(
         State storage self,
+        DepegSwap storage ds,
         address owner,
-        address receiver,
         uint256 amount,
         IUniswapV2Router02 ammRouter,
-        IDsFlashSwapCore flashSwapRouter
-    ) external returns (uint256 attributedRa, uint256 attributedPa) {
-        uint256 dsId = self.globalAssetIdx;
-        DepegSwap storage ds = self.ds[dsId];
-
+        IDsFlashSwapCore flashSwapRouter,
+        uint256 dsId
+    ) internal{
         uint256 userEligible = self.vault.pool.withdrawEligible[owner];
 
         if (userEligible == 0 && !ds.isExpired()) {
@@ -709,21 +734,21 @@ library VaultLibrary {
             _liquidatedLp(self, dsId, ammRouter, flashSwapRouter);
             assert(self.vault.balances.ra.locked == 0);
         }
+    }
 
-        uint256 burnUserAmount;
-        uint256 burnSelfAmount;
-
-        (attributedRa, attributedPa, burnUserAmount, burnSelfAmount) = self
-            .vault
-            .pool
-            .redeem(amount, owner);
-
+    function _processRedeemExpired(
+        State storage self,
+        address owner,
+        address receiver,
+        uint256 attributedRa,
+        uint256 attributedPa,
+        uint256 burnUserAmount,
+        uint256 burnSelfAmount
+    ) internal {
         //ra
         IERC20(self.info.pair1).transfer(receiver, attributedRa);
         //pa
         IERC20(self.info.pair0).transfer(receiver, attributedPa);
-
-        assert(burnSelfAmount + burnUserAmount == amount);
 
         self.vault.lv.burnSelf(burnSelfAmount);
 
@@ -733,6 +758,67 @@ library VaultLibrary {
                 burnUserAmount
             );
         }
+    }
+
+    function redeemExpired(
+        State storage self,
+        address owner,
+        address receiver,
+        uint256 amount,
+        IUniswapV2Router02 ammRouter,
+        IDsFlashSwapCore flashSwapRouter,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external returns (uint256 attributedRa, uint256 attributedPa) {
+        {
+            uint256 dsId = self.globalAssetIdx;
+            DepegSwap storage ds = self.ds[dsId];
+
+            _redeemExpired(self, ds, owner, amount, ammRouter, flashSwapRouter, dsId);
+        }
+
+        uint256 burnUserAmount;
+        uint256 burnSelfAmount;
+
+        (attributedRa, attributedPa, burnUserAmount, burnSelfAmount) = self
+            .vault
+            .pool
+            .redeem(amount, owner);
+        assert(burnSelfAmount + burnUserAmount == amount);
+
+        DepegSwapLibrary.permit(
+            self.vault.lv._address,
+            rawLvPermitSig,
+            owner,
+            address(this),
+            burnUserAmount,
+            deadline
+        );
+        _processRedeemExpired(self, owner, receiver, attributedRa, attributedPa, burnUserAmount, burnSelfAmount);
+    }
+
+    function redeemExpired(
+        State storage self,
+        address owner,
+        address receiver,
+        uint256 amount,
+        IUniswapV2Router02 ammRouter,
+        IDsFlashSwapCore flashSwapRouter
+    ) external returns (uint256 attributedRa, uint256 attributedPa) {
+        uint256 dsId = self.globalAssetIdx;
+        DepegSwap storage ds = self.ds[dsId];
+
+        _redeemExpired(self, ds, owner, amount, ammRouter, flashSwapRouter, dsId);
+        uint256 burnUserAmount;
+        uint256 burnSelfAmount;
+
+        (attributedRa, attributedPa, burnUserAmount, burnSelfAmount) = self
+            .vault
+            .pool
+            .redeem(amount, owner);
+        assert(burnSelfAmount + burnUserAmount == amount);
+
+        _processRedeemExpired(self, owner, receiver, attributedRa, attributedPa, burnUserAmount, burnSelfAmount);
     }
 
     function previewRedeemExpired(
@@ -850,16 +936,14 @@ library VaultLibrary {
     // final amount(Fa) :
     // Fa = rA - fee(rA)
     // TODO : fix this
-    function redeemEarly(
+    function _redeemEarly(
         State storage self,
         address owner,
         address receiver,
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter,
         IUniswapV2Router02 ammRouter
-    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage) {
-        safeBeforeExpired(self);
-
+    ) internal returns (uint256 received, uint256 fee, uint256 feePrecentage) {
         feePrecentage = self.vault.config.fee;
 
         received = _liquidateLpPartial(
@@ -893,6 +977,40 @@ library VaultLibrary {
 
         ERC20Burnable(self.vault.lv._address).burnFrom(owner, amount);
         self.vault.balances.ra.unlockToUnchecked(received, receiver);
+    }
+
+    function redeemEarly(
+        State storage self,
+        address owner,
+        address receiver,
+        uint256 amount,
+        IDsFlashSwapCore flashSwapRouter,
+        IUniswapV2Router02 ammRouter,
+        bytes memory rawLvPermitSig,
+        uint256 deadline
+    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage) {
+        safeBeforeExpired(self);
+        DepegSwapLibrary.permit(
+            self.vault.lv._address,
+            rawLvPermitSig,
+            owner,
+            address(this),
+            amount,
+            deadline
+        );
+        return _redeemEarly(self, owner, receiver, amount, flashSwapRouter, ammRouter);
+    }
+
+    function redeemEarly(
+        State storage self,
+        address owner,
+        address receiver,
+        uint256 amount,
+        IDsFlashSwapCore flashSwapRouter,
+        IUniswapV2Router02 ammRouter
+    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage) {
+        safeBeforeExpired(self);
+        return _redeemEarly(self, owner, receiver, amount, flashSwapRouter, ammRouter);
     }
 
     function previewRedeemEarly(


### PR DESCRIPTION
# Changes

List of Changes:
### PSM

- [x]  add function that doesn't use permit for [redeemRaWithDs](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IPSMcore.sol#L102)
- [x]  add mutex lock to both redeemRaWithDs function
- [x]  add function that doesn't use permit for [redeemWithCT](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IPSMcore.sol#L116)
- [x]  add mutex lock to both redeemWithCT function
- [x]  add function that use permit for CT and DS on [redeemRaWithCtDs](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IPSMcore.sol#L130)
- [x]  add mutex lock to both redeemRaWithCtDs function
- [x]  refactor function that has permit for CT and DS [redeemRaWithCtDs](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IPSMcore.sol#L130)

### LV

- [x]  add function that use permit for LV on [redeemExpiredLv](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IVault.sol#L118)
- [x]  add mutex lock to both redeemExpiredLv function
- [x]  add function that use permit for LV on [redeemEarlyLv](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IVault.sol#L147)
- [x]  add mutex lock to both redeemEarlyLv function
- [x]  add function that use permit for LV on [requestRedemption](https://github.com/Cork-Technology/Depeg-swap/blob/main/contracts/interfaces/IVault.sol#L98)