### PR TITLE
Refactor/dynamic ds price

### DIFF
--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -45,8 +45,8 @@ contract CorkConfig is AccessControl, Pausable {
     /**
      * @dev Initialize Module Core
      */
-    function initializeModuleCore(address pa, address ra, uint256 lvFee) external onlyManager {
-        moduleCore.initialize(pa, ra, lvFee);
+    function initializeModuleCore(address pa, address ra, uint256 lvFee, uint256 initialDsPrice) external onlyManager {
+        moduleCore.initialize(pa, ra, lvFee, initialDsPrice);
     }
 
     /**

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -30,7 +30,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         return PairLibrary.initalize(pa, ra).toId();
     }
 
-    function initialize(address pa, address ra, uint256 lvFee) external override onlyConfig {
+    function initialize(address pa, address ra, uint256 lvFee, uint256 initialDsPrice) external override onlyConfig {
         Pair memory key = PairLibrary.initalize(pa, ra);
         Id id = key.toId();
 
@@ -45,7 +45,7 @@ contract ModuleCore is PsmCore, Initialize, VaultCore {
         address lv = assetsFactory.deployLv(ra, pa, address(this));
 
         PsmLibrary.initialize(state, key);
-        VaultLibrary.initialize(state.vault, lv, lvFee, ra);
+        VaultLibrary.initialize(state.vault, lv, lvFee, ra, initialDsPrice);
 
         emit Initialized(id, pa, ra, lv);
     }

--- a/contracts/interfaces/Init.sol
+++ b/contracts/interfaces/Init.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.24;
 import {Id} from "../libraries/Pair.sol";
 
 interface Initialize {
-    function initialize(address pa, address ra, uint256 lvFee) external;
+    function initialize(address pa, address ra, uint256 lvFee, uint256 initialDsPrice) external;
 
     function issueNewDs(Id id, uint256 expiry, uint256 exchangeRates, uint256 repurchaseFeePrecentage) external;
 

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -28,11 +28,11 @@ struct ReserveState {
 library DsFlashSwaplibrary {
     /// @dev the precentage amount of reserve that will be used to fill buy orders
     /// the router will sell in respect to this ratio on first issuance
-    uint256 public constant INITIAL_RESERVE_SELL_PRESSURE_PRECENTAGE = 501e8;
+    uint256 public constant INITIAL_RESERVE_SELL_PRESSURE_PRECENTAGE = 50e18;
 
     /// @dev the precentage amount of reserve that will be used to fill buy orders
     /// the router will sell in respect to this ratio on subsequent issuances
-    uint256 public constant SUBSEQUENT_RESERVE_SELL_PRESSURE_PRECENTAGE = 801e8;
+    uint256 public constant SUBSEQUENT_RESERVE_SELL_PRESSURE_PRECENTAGE = 80e18;
 
     function onNewIssuance(
         ReserveState storage self,

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -71,13 +71,12 @@ struct VaultState {
     LvAsset lv;
     BitMaps.BitMap lpLiquidated;
     VaultPool pool;
+    uint256 initialDsPrice;
 }
 
 struct VaultConfig {
     // 1 % = 1e18
     uint256 fee;
-    uint256 lpRaBalance;
-    uint256 lpCtBalance;
     uint256 lpBalance;
     bool isDepositPaused;
     bool isWithdrawalPaused;

--- a/contracts/libraries/VaultConfig.sol
+++ b/contracts/libraries/VaultConfig.sol
@@ -7,8 +7,6 @@ library VaultConfigLibrary {
     function initialize(uint256 fee) internal pure returns (VaultConfig memory) {
         return VaultConfig({
             fee: fee,
-            lpRaBalance: 0,
-            lpCtBalance: 0,
             lpBalance: 0,
             isDepositPaused: false,
             isWithdrawalPaused: false

--- a/contracts/libraries/VaultConfig.sol
+++ b/contracts/libraries/VaultConfig.sol
@@ -9,12 +9,7 @@ library VaultConfigLibrary {
         if (fee > 5 ether) {
             revert ICommon.InvalidFees();
         }
-        return VaultConfig({
-            fee: fee,
-            lpBalance: 0,
-            isDepositPaused: false,
-            isWithdrawalPaused: false
-        });
+        return VaultConfig({fee: fee, lpBalance: 0, isDepositPaused: false, isWithdrawalPaused: false});
     }
 
     function updateFee(VaultConfig storage self, uint256 fee) internal {

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -38,7 +38,9 @@ library VaultLibrary {
     /// @notice inssuficient balance to perform expiry redeem(e.g requesting 5 LV to redeem but trying to redeem 10)
     error InsufficientBalance(address caller, uint256 requested, uint256 balance);
 
-    function initialize(VaultState storage self, address lv, uint256 fee, address ra, uint256 initialDsPrice) external {
+    function initialize(VaultState storage self, address lv, uint256 fee, address ra, uint256 initialDsPrice)
+        external
+    {
         self.config = VaultConfigLibrary.initialize(fee);
 
         self.lv = LvAssetLibrary.initialize(lv);

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -31,9 +31,6 @@ library VaultLibrary {
     using VaultPoolLibrary for VaultPool;
     using SafeERC20 for IERC20;
 
-    /// @notice this will set the initial CT price to 0.9 RA, thus also making the initial price of DS to be 0.1 RA
-    uint256 internal constant DEFAULT_AMM_DEPOSIT_RATIO = 9e17;
-
     /// @notice caller is not authorized to perform the action, e.g transfering
     /// redemption rights to another address while not having the rights
     error Unauthorized(address caller);
@@ -41,11 +38,12 @@ library VaultLibrary {
     /// @notice inssuficient balance to perform expiry redeem(e.g requesting 5 LV to redeem but trying to redeem 10)
     error InsufficientBalance(address caller, uint256 requested, uint256 balance);
 
-    function initialize(VaultState storage self, address lv, uint256 fee, address ra) external {
+    function initialize(VaultState storage self, address lv, uint256 fee, address ra, uint256 initialDsPrice) external {
         self.config = VaultConfigLibrary.initialize(fee);
 
         self.lv = LvAssetLibrary.initialize(lv);
         self.balances.ra = RedemptionAssetManagerLibrary.initialize(ra);
+        self.initialDsPrice = initialDsPrice;
     }
 
     function __addLiquidityToAmmUnchecked(
@@ -137,8 +135,8 @@ library VaultLibrary {
         view
         returns (uint256 ratio)
     {
-        // This basically means that if the reserve is empty, then we use the default ratio
-        ratio = DEFAULT_AMM_DEPOSIT_RATIO;
+        // This basically means that if the reserve is empty, then we use the default ratio supplied at deployment
+        ratio = self.ds[dsId].exchangeRate() - self.vault.initialDsPrice;
 
         // will always fail for the first deposit
         try flashSwapRouter.getCurrentPriceRatio(self.info.toId(), dsId) returns (uint256, uint256 _ctRatio) {

--- a/test/contracts/CorkConfig.ts
+++ b/test/contracts/CorkConfig.ts
@@ -21,6 +21,8 @@ describe("CorkConfig", function () {
   let moduleCore: Awaited<ReturnType<typeof getModuleCore>>;
   let corkConfig: Awaited<ReturnType<typeof getCorkConfig>>;
   let pa: Awaited<ReturnType<typeof getPA>>;
+  
+  const initialDsPrice = parseEther("0.1");
 
   let Id: Awaited<ReturnType<typeof moduleCore.read.getId>>;
 
@@ -133,7 +135,7 @@ describe("CorkConfig", function () {
       const { pa, ra } = await loadFixture(helper.backedAssets);
       await expect(
         await corkConfig.write.initializeModuleCore(
-          [pa.address, ra.address, fixture.lvFee],
+          [pa.address, ra.address, fixture.lvFee, initialDsPrice],
           {
             account: defaultSigner.account,
           }
@@ -144,7 +146,7 @@ describe("CorkConfig", function () {
     it("Revert when non MANAGER call initializeModuleCore", async function () {
       await expect(
         corkConfig.write.initializeModuleCore(
-          [pa.address, fixture.ra.address, fixture.lvFee],
+          [pa.address, fixture.ra.address, fixture.lvFee, initialDsPrice],
           {
             account: secondSigner.account,
           }

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -30,6 +30,7 @@ describe("Module Core", function () {
 
   let moduleCore: Awaited<ReturnType<typeof getModuleCore>>;
   let corkConfig: Awaited<ReturnType<typeof getCorkConfig>>;
+  const initialDsPrice = parseEther("0.1");
 
   const getModuleCore = async (address: Address) => {
     return await hre.viem.getContractAt("ModuleCore", address);
@@ -145,10 +146,12 @@ describe("Module Core", function () {
           [pa.address, ra.address]
         )
       ) as `0x${string}`;
+      
       await corkConfig.write.initializeModuleCore([
         pa.address,
         ra.address,
         fixture.lvFee,
+        initialDsPrice,
       ]);
       const events = await moduleCore.getEvents.Initialized({
         id: expectedId,
@@ -172,6 +175,7 @@ describe("Module Core", function () {
           fixture.pa.address,
           fixture.ra.address,
           fixture.lvFee,
+          initialDsPrice,
         ])
       ).to.be.rejectedWith("AlreadyInitialized()");
     });
@@ -182,6 +186,7 @@ describe("Module Core", function () {
           fixture.pa.address,
           fixture.ra.address,
           fixture.lvFee,
+          initialDsPrice,
         ])
       ).to.be.rejectedWith("OnlyConfigAllowed()");
     });

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -243,8 +243,7 @@ export type InitializeNewPsmArg = {
   pa: Address;
   ra: Address;
   lvFee: bigint;
-  lvAmmWaDepositThreshold: bigint;
-  lvAmmCtDepositThreshold: bigint;
+  initialDsPrice?: bigint;
 };
 
 export async function initializeNewPsmLv(arg: InitializeNewPsmArg) {
@@ -252,12 +251,13 @@ export async function initializeNewPsmLv(arg: InitializeNewPsmArg) {
   const { defaultSigner } = getSigners(signers);
   const contract = await hre.viem.getContractAt("ModuleCore", arg.moduleCore);
   const configContract = await hre.viem.getContractAt("CorkConfig", arg.config);
+  const dsPrice = arg.initialDsPrice ?? parseEther("0.1");
 
   await configContract.write.setModuleCore([arg.moduleCore], {
     account: defaultSigner.account,
   });
 
-  await configContract.write.initializeModuleCore([arg.pa, arg.ra, arg.lvFee], {
+  await configContract.write.initializeModuleCore([arg.pa, arg.ra, arg.lvFee, dsPrice], {
     account: defaultSigner.account,
   });
 
@@ -496,8 +496,6 @@ export async function ModuleCoreWithInitializedPsmLv(
   const { pa, ra } = await backedAssets();
 
   const fee = parseEther("10");
-  // 0 for now cause we dont have any amm
-  const depositThreshold = parseEther("0");
 
   const { Id, lv } = await initializeNewPsmLv({
     moduleCore: moduleCore.address,
@@ -505,8 +503,6 @@ export async function ModuleCoreWithInitializedPsmLv(
     pa: pa.address,
     ra: ra.address,
     lvFee: fee,
-    lvAmmWaDepositThreshold: depositThreshold,
-    lvAmmCtDepositThreshold: depositThreshold,
   });
 
   return {
@@ -518,8 +514,6 @@ export async function ModuleCoreWithInitializedPsmLv(
     ra,
     Id: Id!,
     lvFee: fee,
-    lvAmmWaDepositThreshold: depositThreshold,
-    lvAmmCtDepositThreshold: depositThreshold,
     dsFlashSwapRouter,
     univ2Factory,
     univ2Router,


### PR DESCRIPTION
# Changes

List of Changes:
 - calculate the initial AMM ratio using initial DS price supplied on initialization
 - remove useless RA and CT balance in vault state


# Notes
- now the AMM ratio is calculated using `DS exchange rate - initialDsPrice` instead of using the default hardcoded one, it needs to be supplied when initializing the vault
