### PR TITLE
claimRolloverProfit function name changed to claimAutoSellProfit 

### DIFF
--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -346,12 +346,12 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         );
     }
 
-    function claimRolloverProfit(Id id, uint256 dsId, uint256 amount)
+    function claimAutoSellProfit(Id id, uint256 dsId, uint256 amount)
         external
         returns (uint256 profit, uint256 dsReceived)
     {
         State storage state = states[id];
-        (profit, dsReceived) = state.claimRolloverProfit(getRouterCore(), _msgSender(), dsId, amount);
+        (profit, dsReceived) = state.claimAutoSellProfit(getRouterCore(), _msgSender(), dsId, amount);
         emit RolloverProfitClaimed(id, dsId, _msgSender(), amount, profit, dsReceived);
     }
 

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -289,7 +289,7 @@ interface IPSMcore is IRepurchase {
         external
         returns (uint256 ctReceived, uint256 dsReceived, uint256 _exchangeRate, uint256 paReceived);
 
-    function claimRolloverProfit(Id id, uint256 prevDsId, uint256 amount) external returns (uint256 profit, uint256 dsReceived);
+    function claimAutoSellProfit(Id id, uint256 prevDsId, uint256 amount) external returns (uint256 profit, uint256 dsReceived);
 
     function updatePsmAutoSellStatus(Id id, address user, bool status) external;
 

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -289,7 +289,9 @@ interface IPSMcore is IRepurchase {
         external
         returns (uint256 ctReceived, uint256 dsReceived, uint256 _exchangeRate, uint256 paReceived);
 
-    function claimAutoSellProfit(Id id, uint256 prevDsId, uint256 amount) external returns (uint256 profit, uint256 dsReceived);
+    function claimAutoSellProfit(Id id, uint256 prevDsId, uint256 amount)
+        external
+        returns (uint256 profit, uint256 dsReceived);
 
     function updatePsmAutoSellStatus(Id id, address user, bool status) external;
 

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -457,7 +457,7 @@ library PsmLibrary {
         bool isPSMWithdrawalPaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
-    ) external{
+    ) external {
         self.psm.isDepositPaused = isPSMDepositPaused;
         self.psm.isWithdrawalPaused = isPSMWithdrawalPaused;
         self.vault.config.isDepositPaused = isLVDepositPaused;
@@ -528,7 +528,7 @@ library PsmLibrary {
         IERC20(ds._address).transfer(buyer, received);
 
         // Provide liquidity
-        VaultLibrary.__provideLiquidityWithRatio(self, fee, flashSwapRouter, ds.ct,ammRouter);
+        VaultLibrary.__provideLiquidityWithRatio(self, fee, flashSwapRouter, ds.ct, ammRouter);
     }
 
     function _redeemDs(Balances storage self, uint256 amount) internal {

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -80,7 +80,7 @@ library PsmLibrary {
         (ctReceived, dsReceived, _exchangeRate, paReceived) = _rolloverCt(self, owner, amount, dsId, flashSwapRouter);
     }
 
-    function claimRolloverProfit(
+    function claimAutoSellProfit(
         State storage self,
         IDsFlashSwapCore flashSwapRouter,
         address owner,
@@ -88,7 +88,7 @@ library PsmLibrary {
         uint256 amount
     ) external returns (uint256 profit, uint256 remainingDsReceived) {
         (profit, remainingDsReceived) =
-            _claimRolloverProfit(self, self.psm.poolArchive[dsId], flashSwapRouter, owner, amount, dsId);
+            _claimAutoSellProfit(self, self.psm.poolArchive[dsId], flashSwapRouter, owner, amount, dsId);
     }
     // 1. check how much expirec CT does use have
     // 2. calculate how much backed RA and PA the user can redeem
@@ -180,7 +180,7 @@ library PsmLibrary {
         ERC20Burnable(prevDs.ct).burnFrom(owner, amount);
     }
 
-    function _claimRolloverProfit(
+    function _claimAutoSellProfit(
         State storage self,
         PsmPoolArchive storage prevArchive,
         IDsFlashSwapCore flashswapRouter,

--- a/test/forge/Rollover.t.sol
+++ b/test/forge/Rollover.t.sol
@@ -156,7 +156,7 @@ contract RolloverTest is Helper {
             moduleCore.rolloverCt(currencyId, DEFAULT_ADDRESS, DEFAULT_DEPOSIT_AMOUNT, prevDsId, permit, deadline);
     }
 
-    function test_ClaimRolloverProfit() external {
+    function test_claimAutoSellProfit() external {
         uint256 prevDsId = dsId;
         uint256 amountOutMin = flashSwapRouter.previewSwapRaforDs(currencyId, dsId, 1 ether);
 
@@ -196,7 +196,7 @@ contract RolloverTest is Helper {
         vm.assertEq(claims, DEFAULT_DEPOSIT_AMOUNT);
 
         (uint256 rolloverProfitReceived, uint256 rolloverDsReceived) =
-            moduleCore.claimRolloverProfit(currencyId, dsId, DEFAULT_DEPOSIT_AMOUNT);
+            moduleCore.claimAutoSellProfit(currencyId, dsId, DEFAULT_DEPOSIT_AMOUNT);
 
         claims = IPSMcore(moduleCore).rolloverProfitRemaining(currencyId, dsId);
         vm.assertEq(claims, 0);
@@ -268,7 +268,7 @@ contract RolloverTest is Helper {
         vm.startPrank(address(69));
         vm.expectRevert();
         (uint256 rolloverProfitReceived, uint256 rolloverDsReceived) =
-            moduleCore.claimRolloverProfit(currencyId, dsId, DEFAULT_DEPOSIT_AMOUNT);
+            moduleCore.claimAutoSellProfit(currencyId, dsId, DEFAULT_DEPOSIT_AMOUNT);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
# Changes

List of Changes:
-Name of the function - "claimRolloverProfit" changed to name - "claimAutoSellProfit" in all contracts, tests, libraries and interfaces 

