### PR TITLE
refactor : fixed typos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 # WETH address, fill this if you want to deploy the protocol to a network that already has WETH deployed(e.g mainnet ETH)
 WETH=0x3BFE8e8821995737187c0Dfb4F26064679EB7C7F
 
-# fee precentage for redeeming RA using DS + PA on PSM in wei. use https://eth-converter.com/ to convert percentage to wei
+# fee percentage for redeeming RA using DS + PA on PSM in wei. use https://eth-converter.com/ to convert percentage to wei
 # for 1 percent, insert 1 to the "Ether" field and copy the value of the "Wei" field
 # default to 0.1%
-PSM_BASE_REDEMPTION_FEE_PRECENTAGE=100000000000000000
+PSM_BASE_REDEMPTION_FEE_PERCENTAGE=100000000000000000

--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -80,23 +80,23 @@ contract CorkConfig is AccessControl, Pausable {
         Id id,
         uint256 expiry,
         uint256 exchangeRates,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         uint256 decayDiscountRateInDays,
         // won't have effect on first issuance
         uint256 rolloverPeriodInblocks
     ) external whenNotPaused onlyManager {
         moduleCore.issueNewDs(
-            id, expiry, exchangeRates, repurchaseFeePrecentage, decayDiscountRateInDays, rolloverPeriodInblocks
+            id, expiry, exchangeRates, repurchaseFeePercentage, decayDiscountRateInDays, rolloverPeriodInblocks
         );
     }
 
     /**
      * @notice Updates fee rates for psm repurchase
      * @param id id of PSM
-     * @param newRepurchaseFeePrecentage new value of repurchase fees, make sure it has 18 decimals(e.g 1% = 1e18)
+     * @param newRepurchaseFeePercentage new value of repurchase fees, make sure it has 18 decimals(e.g 1% = 1e18)
      */
-    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePrecentage) external onlyManager {
-        moduleCore.updateRepurchaseFeeRate(id, newRepurchaseFeePrecentage);
+    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePercentage) external onlyManager {
+        moduleCore.updateRepurchaseFeeRate(id, newRepurchaseFeePercentage);
     }
 
     /**
@@ -130,10 +130,10 @@ contract CorkConfig is AccessControl, Pausable {
 
     /**
      * @notice Updates base redemption fee percentage
-     * @param newPsmBaseRedemptionFeePrecentage new value of fees, make sure it has 18 decimals(e.g 1% = 1e18)
+     * @param newPsmBaseRedemptionFeePercentage new value of fees, make sure it has 18 decimals(e.g 1% = 1e18)
      */
-    function updatePsmBaseRedemptionFeePrecentage(uint256 newPsmBaseRedemptionFeePrecentage) external onlyManager {
-        moduleCore.updatePsmBaseRedemptionFeePrecentage(newPsmBaseRedemptionFeePrecentage);
+    function updatePsmBaseRedemptionFeePercentage(uint256 newPsmBaseRedemptionFeePercentage) external onlyManager {
+        moduleCore.updatePsmBaseRedemptionFeePercentage(newPsmBaseRedemptionFeePercentage);
     }
 
     function updateFlashSwapRouterDiscountInDays(Id id, uint256 newDiscountInDays) external onlyManager {

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -30,12 +30,12 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         address _flashSwapRouter,
         address _ammRouter,
         address _config,
-        uint256 _psmBaseRedemptionFeePrecentage
+        uint256 _psmBaseRedemptionFeePercentage
     ) external initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         initializeModuleState(
-            _swapAssetFactory, _ammFactory, _flashSwapRouter, _ammRouter, _config, _psmBaseRedemptionFeePrecentage
+            _swapAssetFactory, _ammFactory, _flashSwapRouter, _ammRouter, _config, _psmBaseRedemptionFeePercentage
         );
     }
 
@@ -82,12 +82,12 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         Id id,
         uint256 expiry,
         uint256 exchangeRates,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         uint256 decayDiscountRateInDays,
         // won't have effect on first issuance
         uint256 rolloverPeriodInblocks
     ) external override onlyConfig onlyInitialized(id) {
-        if (repurchaseFeePrecentage > 5 ether) {
+        if (repurchaseFeePercentage > 5 ether) {
             revert InvalidFees();
         }
 
@@ -100,7 +100,7 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         );
 
         // avoid stack to deep error
-        _initOnNewIssuance(id, repurchaseFeePrecentage, ra, ct, ds, expiry);
+        _initOnNewIssuance(id, repurchaseFeePercentage, ra, ct, ds, expiry);
         // avoid stack to deep error
         getRouterCore().setDecayDiscountAndRolloverPeriodOnNewIssuance(
             id, decayDiscountRateInDays, rolloverPeriodInblocks
@@ -110,7 +110,7 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
 
     function _initOnNewIssuance(
         Id id,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         address ra,
         address ct,
         address ds,
@@ -123,18 +123,18 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
 
         address ammPair = getAmmFactory().createPair(ra, ct);
 
-        PsmLibrary.onNewIssuance(state, ct, ds, ammPair, idx, prevIdx, repurchaseFeePrecentage);
+        PsmLibrary.onNewIssuance(state, ct, ds, ammPair, idx, prevIdx, repurchaseFeePercentage);
 
         getRouterCore().onNewIssuance(id, idx, ds, ammPair, 0, ra, ct);
 
         emit Issued(id, idx, expiry, ds, ct, ammPair);
     }
 
-    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePrecentage) external onlyConfig {
+    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePercentage) external onlyConfig {
         State storage state = states[id];
-        PsmLibrary.updateRepurchaseFeePercentage(state, newRepurchaseFeePrecentage);
+        PsmLibrary.updateRepurchaseFeePercentage(state, newRepurchaseFeePercentage);
 
-        emit RepurchaseFeeRateUpdated(id, newRepurchaseFeePrecentage);
+        emit RepurchaseFeeRateUpdated(id, newRepurchaseFeePercentage);
     }
 
     function updateEarlyRedemptionFeeRate(Id id, uint256 newEarlyRedemptionFeeRate) external onlyConfig {
@@ -193,12 +193,12 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
 
     /**
      * @notice update value of PSMBaseRedemption fees
-     * @param newPsmBaseRedemptionFeePrecentage new value of fees
+     * @param newPsmBaseRedemptionFeePercentage new value of fees
      */
-    function updatePsmBaseRedemptionFeePrecentage(uint256 newPsmBaseRedemptionFeePrecentage) external onlyConfig {
-        if (newPsmBaseRedemptionFeePrecentage > 5 ether) {
+    function updatePsmBaseRedemptionFeePercentage(uint256 newPsmBaseRedemptionFeePercentage) external onlyConfig {
+        if (newPsmBaseRedemptionFeePercentage > 5 ether) {
             revert InvalidFees();
         }
-        psmBaseRedemptionFeePrecentage = newPsmBaseRedemptionFeePrecentage;
+        psmBaseRedemptionFeePercentage = newPsmBaseRedemptionFeePercentage;
     }
 }

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -30,7 +30,7 @@ abstract contract ModuleState is ICommon {
 
     address internal CONFIG;
 
-    uint256 internal psmBaseRedemptionFeePrecentage;
+    uint256 internal psmBaseRedemptionFeePercentage;
 
     /**
      * @dev checks if caller is config contract or not
@@ -52,9 +52,9 @@ abstract contract ModuleState is ICommon {
         address _dsFlashSwapRouter,
         address _ammRouter,
         address _config,
-        uint256 _psmBaseRedemptionFeePrecentage
+        uint256 _psmBaseRedemptionFeePercentage
     ) internal {
-        if (psmBaseRedemptionFeePrecentage > 5 ether) {
+        if (psmBaseRedemptionFeePercentage > 5 ether) {
             revert InvalidFees();
         }
         SWAP_ASSET_FACTORY = _swapAssetFactory;
@@ -62,7 +62,7 @@ abstract contract ModuleState is ICommon {
         DS_FLASHSWAP_ROUTER = _dsFlashSwapRouter;
         AMM_ROUTER = _ammRouter;
         CONFIG = _config;
-        psmBaseRedemptionFeePrecentage = _psmBaseRedemptionFeePrecentage;
+        psmBaseRedemptionFeePercentage = _psmBaseRedemptionFeePercentage;
     }
 
     function getRouterCore() internal view returns (RouterState) {

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -18,12 +18,12 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     using PairLibrary for Pair;
 
     /**
-     * @notice returns the fee precentage for repurchasing(1e18 = 1%)
+     * @notice returns the fee percentage for repurchasing(1e18 = 1%)
      * @param id the id of PSM
      */
     function repurchaseFee(Id id) external view override returns (uint256) {
         State storage state = states[id];
-        return state.repurchaseFeePrecentage();
+        return state.repurchaseFeePercentage();
     }
 
     /**
@@ -34,13 +34,13 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     function repurchase(Id id, uint256 amount)
         external
         override
-        returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates)
+        returns (uint256 dsId, uint256 received, uint256 feePercentage, uint256 fee, uint256 exchangeRates)
     {
         State storage state = states[id];
-        (dsId, received, feePrecentage, fee, exchangeRates) =
+        (dsId, received, feePercentage, fee, exchangeRates) =
             state.repurchase(_msgSender(), amount, getRouterCore(), getAmmRouter());
 
-        emit Repurchased(id, _msgSender(), dsId, amount, received, feePrecentage, fee, exchangeRates);
+        emit Repurchased(id, _msgSender(), dsId, amount, received, feePercentage, fee, exchangeRates);
     }
 
     /**
@@ -49,7 +49,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
      * @param amount the amount of RA to use
      * @return dsId the id of the DS
      * @return received the amount of RA received
-     * @return feePrecentage the fee in precentage
+     * @return feePercentage the fee in percentage
      * @return fee the fee charged
      * @return exchangeRates the effective DS exchange rate at the time of repurchase
      */
@@ -57,10 +57,10 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         external
         view
         override
-        returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates)
+        returns (uint256 dsId, uint256 received, uint256 feePercentage, uint256 fee, uint256 exchangeRates)
     {
         State storage state = states[id];
-        (dsId, received, feePrecentage, fee, exchangeRates,) = state.previewRepurchase(amount);
+        (dsId, received, feePercentage, fee, exchangeRates,) = state.previewRepurchase(amount);
     }
 
     /**
@@ -134,14 +134,14 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     {
         State storage state = states[id];
         // gas savings
-        uint256 feePrecentage = psmBaseRedemptionFeePrecentage;
+        uint256 feePercentage = psmBaseRedemptionFeePercentage;
 
         (received, _exchangeRate, fee) =
-            state.redeemWithDs(_msgSender(), amount, dsId, rawDsPermitSig, deadline, feePrecentage);
+            state.redeemWithDs(_msgSender(), amount, dsId, rawDsPermitSig, deadline, feePercentage);
 
         VaultLibrary.provideLiquidityWithFee(state, fee, getRouterCore(), getAmmRouter());
 
-        emit DsRedeemed(id, dsId, _msgSender(), amount, received, _exchangeRate, feePrecentage, fee);
+        emit DsRedeemed(id, dsId, _msgSender(), amount, received, _exchangeRate, feePercentage, fee);
     }
 
     function redeemRaWithDs(Id id, uint256 dsId, uint256 amount)
@@ -154,13 +154,13 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     {
         State storage state = states[id];
         // gas savings
-        uint256 feePrecentage = psmBaseRedemptionFeePrecentage;
+        uint256 feePercentage = psmBaseRedemptionFeePercentage;
 
-        (received, _exchangeRate, fee) = state.redeemWithDs(_msgSender(), amount, dsId, bytes(""), 0, feePrecentage);
+        (received, _exchangeRate, fee) = state.redeemWithDs(_msgSender(), amount, dsId, bytes(""), 0, feePercentage);
 
         VaultLibrary.provideLiquidityWithFee(state, fee, getRouterCore(), getAmmRouter());
 
-        emit DsRedeemed(id, dsId, _msgSender(), amount, received, _exchangeRate, feePrecentage, fee);
+        emit DsRedeemed(id, dsId, _msgSender(), amount, received, _exchangeRate, feePercentage, fee);
     }
 
     /**
@@ -304,7 +304,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
      * @notice returns base redemption fees (1e18 = 1%)
      */
     function baseRedemptionFee() external view override returns (uint256) {
-        return psmBaseRedemptionFeePrecentage;
+        return psmBaseRedemptionFeePercentage;
     }
 
     function psmAcceptFlashSwapProfit(Id id, uint256 profit) external onlyFlashSwapRouter {

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -63,13 +63,13 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         override
         nonReentrant
         LVWithdrawalNotPaused(id)
-        returns (uint256 received, uint256 fee, uint256 feePrecentage)
+        returns (uint256 received, uint256 fee, uint256 feePercentage)
     {
-        (received, fee, feePrecentage) = states[id].redeemEarly(
+        (received, fee, feePercentage) = states[id].redeemEarly(
             _msgSender(), receiver, amount, getRouterCore(), getAmmRouter(), rawLvPermitSig, deadline, amountOutMin
         );
 
-        emit LvRedeemEarly(id, _msgSender(), receiver, received, fee, feePrecentage);
+        emit LvRedeemEarly(id, _msgSender(), receiver, received, fee, feePercentage);
     }
 
     /**
@@ -84,14 +84,14 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         override
         nonReentrant
         LVWithdrawalNotPaused(id)
-        returns (uint256 received, uint256 fee, uint256 feePrecentage)
+        returns (uint256 received, uint256 fee, uint256 feePercentage)
     {
         State storage state = states[id];
-        (received, fee, feePrecentage) = state.redeemEarly(
+        (received, fee, feePercentage) = state.redeemEarly(
             _msgSender(), receiver, amount, getRouterCore(), getAmmRouter(), bytes(""), 0, amountOutMin
         );
 
-        emit LvRedeemEarly(id, _msgSender(), receiver, received, fee, feePrecentage);
+        emit LvRedeemEarly(id, _msgSender(), receiver, received, fee, feePercentage);
     }
 
     /**
@@ -104,10 +104,10 @@ abstract contract VaultCore is ModuleState, Context, IVault {
         view
         override
         LVWithdrawalNotPaused(id)
-        returns (uint256 received, uint256 fee, uint256 feePrecentage)
+        returns (uint256 received, uint256 fee, uint256 feePercentage)
     {
         State storage state = states[id];
-        (received, fee, feePrecentage) = state.previewRedeemEarly(amount, getRouterCore());
+        (received, fee, feePercentage) = state.previewRedeemEarly(amount, getRouterCore());
     }
 
     /**

--- a/contracts/core/flash-swaps/FlashSwapRouter.sol
+++ b/contracts/core/flash-swaps/FlashSwapRouter.sol
@@ -267,7 +267,7 @@ contract RouterState is
 
         // calculate the amount of DS tokens that will be sold from reserve
         uint256 amountSellFromReserve =
-            amountOut - MathHelper.calculatePrecentageFee(self.reserveSellPressurePrecentage, amountOut);
+            amountOut - MathHelper.calculatePercentageFee(self.reserveSellPressurePercentage, amountOut);
 
         // sell all tokens if the sell amount is higher than the available reserve
         amountSellFromReserve = assetPair.lvReserve + assetPair.psmReserve < amountSellFromReserve
@@ -404,7 +404,7 @@ contract RouterState is
 
         // calculate the amount of DS tokens that will be sold from reserve
         uint256 amountSellFromReserve =
-            amountOut - MathHelper.calculatePrecentageFee(self.reserveSellPressurePrecentage, amountOut);
+            amountOut - MathHelper.calculatePercentageFee(self.reserveSellPressurePercentage, amountOut);
 
         // sell all tokens if the sell amount is higher than the available reserve
         amountSellFromReserve = assetPair.lvReserve + assetPair.psmReserve < amountSellFromReserve

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -65,7 +65,7 @@ interface IPSMcore is IRepurchase {
     /// @param amount The amount of the DS redeemed
     /// @param received The amount of  asset received
     /// @param dsExchangeRate The exchange rate of DS at the time of redeem
-    /// @param feePrecentage The fee precentage charged for redemption
+    /// @param feePercentage The fee percentage charged for redemption
     /// @param fee The fee charged for redemption
     event DsRedeemed(
         Id indexed Id,
@@ -74,7 +74,7 @@ interface IPSMcore is IRepurchase {
         uint256 amount,
         uint256 received,
         uint256 dsExchangeRate,
-        uint256 feePrecentage,
+        uint256 feePercentage,
         uint256 fee
     );
 

--- a/contracts/interfaces/IRepurchase.sol
+++ b/contracts/interfaces/IRepurchase.sol
@@ -16,7 +16,7 @@ interface IRepurchase {
      * @param raUsed the amount of RA used
      * @param received the amount of RA used
      * @param fee the fee charged
-     * @param feePrecentage the fee in precentage
+     * @param feePercentage the fee in percentage
      * @param exchangeRates the effective DS exchange rate at the time of repurchase
      */
     event Repurchased(
@@ -25,7 +25,7 @@ interface IRepurchase {
         uint256 indexed dsId,
         uint256 raUsed,
         uint256 received,
-        uint256 feePrecentage,
+        uint256 feePercentage,
         uint256 fee,
         uint256 exchangeRates
     );
@@ -43,7 +43,7 @@ interface IRepurchase {
     error InsufficientLiquidity(uint256 available, uint256 requested);
 
     /**
-     * @notice returns the fee precentage for repurchasing(1e18 = 1%)
+     * @notice returns the fee percentage for repurchasing(1e18 = 1%)
      * @param id the id of PSM
      */
     function repurchaseFee(Id id) external view returns (uint256);
@@ -55,7 +55,7 @@ interface IRepurchase {
      */
     function repurchase(Id id, uint256 amount)
         external
-        returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates);
+        returns (uint256 dsId, uint256 received, uint256 feePercentage, uint256 fee, uint256 exchangeRates);
 
     /**
      * @notice returns the amount of pa and ds tokens that will be received after repurchasing
@@ -63,14 +63,14 @@ interface IRepurchase {
      * @param amount the amount of RA to use
      * @return dsId the id of the DS
      * @return received the amount of RA received
-     * @return feePrecentage the fee in precentage
+     * @return feePercentage the fee in percentage
      * @return fee the fee charged
      * @return exchangeRates the effective DS exchange rate at the time of repurchase
      */
     function previewRepurchase(Id id, uint256 amount)
         external
         view
-        returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates);
+        returns (uint256 dsId, uint256 received, uint256 feePercentage, uint256 fee, uint256 exchangeRates);
 
     /**
      * @notice return the amount of available PA and DS to purchase.

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -19,14 +19,14 @@ interface IVault {
     /// @param receiver The address of the receiver
     /// @param amount The amount of the asset redeemed
     /// @param fee The total fee charged for early redemption
-    /// @param feePrecentage The fee precentage for early redemption, denominated in 1e18 (e.g 100e18 = 100%)
+    /// @param feePercentage The fee percentage for early redemption, denominated in 1e18 (e.g 100e18 = 100%)
     event LvRedeemEarly(
         Id indexed Id,
         address indexed redeemer,
         address indexed receiver,
         uint256 amount,
         uint256 fee,
-        uint256 feePrecentage
+        uint256 feePercentage
     );
 
     /// @notice Emitted when a early redemption fee is updated for a given Vault
@@ -62,7 +62,7 @@ interface IVault {
         bytes memory rawLvPermitSig,
         uint256 deadline,
         uint256 amountOutMin
-    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage);
+    ) external returns (uint256 received, uint256 fee, uint256 feePercentage);
 
     /**
      * @notice Redeem lv before expiry
@@ -73,7 +73,7 @@ interface IVault {
      */
     function redeemEarlyLv(Id id, address receiver, uint256 amount, uint256 amountOutMin)
         external
-        returns (uint256 received, uint256 fee, uint256 feePrecentage);
+        returns (uint256 received, uint256 fee, uint256 feePercentage);
 
     /**
      * @notice preview redeem lv before expiry
@@ -83,7 +83,7 @@ interface IVault {
     function previewRedeemEarlyLv(Id id, uint256 amount)
         external
         view
-        returns (uint256 received, uint256 fee, uint256 feePrecentage);
+        returns (uint256 received, uint256 fee, uint256 feePercentage);
 
     /**
      * Returns the early redemption fee percentage

--- a/contracts/interfaces/Init.sol
+++ b/contracts/interfaces/Init.sol
@@ -23,7 +23,7 @@ interface Initialize {
      * @param id the id of the pair
      * @param expiry time in seconds after which the DS will expire
      * @param exchangeRates the exchange rate of the DS, token that are non-rebasing MUST set this to 1e18, and rebasing tokens should set this to the current exchange rate in the market
-     * @param repurchaseFeePrecentage the repurchase fee for the DS, make sure it has 18 decimals(e.g 1% = 1e18)
+     * @param repurchaseFeePercentage the repurchase fee for the DS, make sure it has 18 decimals(e.g 1% = 1e18)
      * @param decayDiscountRateInDays the decay discount rate in days, make sure it has 18 decimals(e.g 1% = 1e18)
      * @param rolloverPeriodInblocks the rollover sale period in blocks(e.g 500 means the rollover would happen right after this block until 500 blocks after the issuance block)
      */
@@ -31,7 +31,7 @@ interface Initialize {
         Id id,
         uint256 expiry,
         uint256 exchangeRates,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         uint256 decayDiscountRateInDays,
         // won't have effect on first issuance
         uint256 rolloverPeriodInblocks
@@ -40,9 +40,9 @@ interface Initialize {
     /**
      * @notice update PSM repurchase fee rate for a pair
      * @param id id of the pair
-     * @param newRepurchaseFeePrecentage new value of repurchase fees, make sure it has 18 decimals(e.g 1% = 1e18)
+     * @param newRepurchaseFeePercentage new value of repurchase fees, make sure it has 18 decimals(e.g 1% = 1e18)
      */
-    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePrecentage) external;
+    function updateRepurchaseFeeRate(Id id, uint256 newRepurchaseFeePercentage) external;
 
     /**
      * @notice update liquidity vault early redemption fee rate for a pair
@@ -68,8 +68,8 @@ interface Initialize {
     ) external;
 
     /**
-     * @notice update PSM base redemption fee precentage
-     * @param newPsmBaseRedemptionFeePrecentage new value of base redemption fees, make sure it has 18 decimals(e.g 1% = 1e18)
+     * @notice update PSM base redemption fee percentage
+     * @param newPsmBaseRedemptionFeePercentage new value of base redemption fees, make sure it has 18 decimals(e.g 1% = 1e18)
      */
-    function updatePsmBaseRedemptionFeePrecentage(uint256 newPsmBaseRedemptionFeePrecentage) external;
+    function updatePsmBaseRedemptionFeePercentage(uint256 newPsmBaseRedemptionFeePercentage) external;
 }

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -30,7 +30,7 @@ struct AssetPair {
 struct ReserveState {
     /// @dev dsId => [RA, CT, DS]
     mapping(uint256 => AssetPair) ds;
-    uint256 reserveSellPressurePrecentage;
+    uint256 reserveSellPressurePercentage;
     uint256 hpaCumulated;
     uint256 vhpaCumulated;
     uint256 decayDiscountRateInDays;
@@ -44,13 +44,13 @@ struct ReserveState {
  * @notice DsFlashSwap library which implements supporting lib and functions flashswap related features for DS/CT
  */
 library DsFlashSwaplibrary {
-    /// @dev the precentage amount of reserve that will be used to fill buy orders
+    /// @dev the percentage amount of reserve that will be used to fill buy orders
     /// the router will sell in respect to this ratio on first issuance
-    uint256 public constant INITIAL_RESERVE_SELL_PRESSURE_PRECENTAGE = 50e18;
+    uint256 public constant INITIAL_RESERVE_SELL_PRESSURE_PERCENTAGE = 50e18;
 
-    /// @dev the precentage amount of reserve that will be used to fill buy orders
+    /// @dev the percentage amount of reserve that will be used to fill buy orders
     /// the router will sell in respect to this ratio on subsequent issuances
-    uint256 public constant SUBSEQUENT_RESERVE_SELL_PRESSURE_PRECENTAGE = 80e18;
+    uint256 public constant SUBSEQUENT_RESERVE_SELL_PRESSURE_PERCENTAGE = 80e18;
 
     uint256 public constant FIRST_ISSUANCE = 1;
 
@@ -65,9 +65,9 @@ library DsFlashSwaplibrary {
     ) internal {
         self.ds[dsId] = AssetPair(Asset(ra), Asset(ct), Asset(ds), IUniswapV2Pair(pair), initialReserve, 0);
 
-        self.reserveSellPressurePrecentage = dsId == FIRST_ISSUANCE
-            ? INITIAL_RESERVE_SELL_PRESSURE_PRECENTAGE
-            : SUBSEQUENT_RESERVE_SELL_PRESSURE_PRECENTAGE;
+        self.reserveSellPressurePercentage = dsId == FIRST_ISSUANCE
+            ? INITIAL_RESERVE_SELL_PRESSURE_PERCENTAGE
+            : SUBSEQUENT_RESERVE_SELL_PRESSURE_PERCENTAGE;
 
         if (dsId != FIRST_ISSUANCE) {
             try SwapperMathLibrary.calculateHPA(self.hpaCumulated, self.vhpaCumulated) returns (uint256 hpa) {

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -145,8 +145,8 @@ library SwapperMathLibrary {
         raBorrowed = dsReceived - SignedMath.abs(raProvided);
     }
 
-    function calculatePrecentage(uint256 amount, uint256 precentage) private pure returns (uint256 result) {
-        result = (((amount * 1e18) * precentage) / (100 * 1e18)) / 1e18;
+    function calculatePercentage(uint256 amount, uint256 percentage) private pure returns (uint256 result) {
+        result = (((amount * 1e18) * percentage) / (100 * 1e18)) / 1e18;
     }
 
     /**
@@ -161,7 +161,7 @@ library SwapperMathLibrary {
     ) external pure returns (uint256 cumulatedHPA) {
         uint256 decay = calculateDecayDiscount(decayDiscountInDays, issuanceTimestamp, currentTime);
 
-        cumulatedHPA = calculatePrecentage(effectiveDsPrice * amount / 1e18, decay);
+        cumulatedHPA = calculatePercentage(effectiveDsPrice * amount / 1e18, decay);
     }
 
     function calculateEffectiveDsPrice(uint256 dsAmount, uint256 raProvided)
@@ -180,7 +180,7 @@ library SwapperMathLibrary {
     ) external pure returns (uint256 cumulatedVHPA) {
         uint256 decay = calculateDecayDiscount(decayDiscountInDays, issuanceTimestamp, currentTime);
 
-        cumulatedVHPA = calculatePrecentage(amount, decay);
+        cumulatedVHPA = calculatePercentage(amount, decay);
     }
 
     function calculateHPA(uint256 cumulatedHPA, uint256 cumulatedVHPA) external pure returns (uint256 hpa) {

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -81,8 +81,8 @@ library MathHelper {
      * @param fee1e18 the fee in 1e18
      * @param amount the amount of lv user want to withdraw
      */
-    function calculatePrecentageFee(uint256 fee1e18, uint256 amount) external pure returns (uint256 precentage) {
-        precentage = (((amount * 1e18) * fee1e18) / (100 * 1e18)) / 1e18;
+    function calculatePercentageFee(uint256 fee1e18, uint256 amount) external pure returns (uint256 percentage) {
+        percentage = (((amount * 1e18) * fee1e18) / (100 * 1e18)) / 1e18;
     }
 
     /**

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -25,7 +25,7 @@ struct State {
  */
 struct PsmState {
     Balances balances;
-    uint256 repurchaseFeePrecentage;
+    uint256 repurchaseFeePercentage;
     BitMaps.BitMap liquiditySeparated;
     /// @dev dsId => PsmPoolArchive
     mapping(uint256 => PsmPoolArchive) poolArchive;

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -616,17 +616,17 @@ library VaultLibrary {
         bytes memory rawLvPermitSig,
         uint256 deadline,
         uint256 amountOutMin
-    ) external returns (uint256 received, uint256 fee, uint256 feePrecentage) {
+    ) external returns (uint256 received, uint256 fee, uint256 feePercentage) {
         safeBeforeExpired(self);
         if (deadline != 0) {
             DepegSwapLibrary.permit(self.vault.lv._address, rawLvPermitSig, owner, address(this), amount, deadline);
         }
 
-        feePrecentage = self.vault.config.fee;
+        feePercentage = self.vault.config.fee;
 
         received = _liquidateLpPartial(self, self.globalAssetIdx, flashSwapRouter, ammRouter, amount);
 
-        fee = MathHelper.calculatePrecentageFee(received, feePrecentage);
+        fee = MathHelper.calculatePercentageFee(received, feePercentage);
 
         if (fee != 0) {
             provideLiquidityWithFee(self, fee, flashSwapRouter, ammRouter);
@@ -644,15 +644,15 @@ library VaultLibrary {
     function previewRedeemEarly(State storage self, uint256 amount, IDsFlashSwapCore flashSwapRouter)
         public
         view
-        returns (uint256 received, uint256 fee, uint256 feePrecentage)
+        returns (uint256 received, uint256 fee, uint256 feePercentage)
     {
         safeBeforeExpired(self);
 
-        feePrecentage = self.vault.config.fee;
+        feePercentage = self.vault.config.fee;
 
         (received,) = _tryLiquidateLpAndSellCtToAmm(self, self.globalAssetIdx, flashSwapRouter, amount);
 
-        fee = MathHelper.calculatePrecentageFee(received, feePrecentage);
+        fee = MathHelper.calculatePercentageFee(received, feePercentage);
 
         received -= fee;
     }

--- a/script/foundry-scripts/Deploy.s.sol
+++ b/script/foundry-scripts/Deploy.s.sol
@@ -32,7 +32,7 @@ contract DeployScript is Script {
     ModuleCore public moduleCore;
 
     bool public isProd = vm.envBool("PRODUCTION");
-    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PRECENTAGE");
+    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PERCENTAGE");
     address public ceth = vm.envAddress("WETH");
     uint256 public pk = vm.envUint("PRIVATE_KEY");
 

--- a/script/foundry-scripts/IncreaseAMMLiquidity.s.sol
+++ b/script/foundry-scripts/IncreaseAMMLiquidity.s.sol
@@ -18,7 +18,7 @@ contract LiquidityScript is Script {
     ModuleCore public moduleCore;
 
     bool public isProd = vm.envBool("PRODUCTION");
-    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PRECENTAGE");
+    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PERCENTAGE");
     address public ceth = vm.envAddress("WETH");
     uint256 public pk = vm.envUint("PRIVATE_KEY");
 

--- a/script/foundry-scripts/IncreaseLvDeposit.s.sol
+++ b/script/foundry-scripts/IncreaseLvDeposit.s.sol
@@ -10,7 +10,7 @@ contract IncreaseDepositScript is Script {
     ModuleCore public moduleCore;
 
     bool public isProd = vm.envBool("PRODUCTION");
-    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PRECENTAGE");
+    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PERCENTAGE");
     address public ceth = vm.envAddress("WETH");
     uint256 public pk = vm.envUint("PRIVATE_KEY");
 

--- a/script/foundry-scripts/TradingComp/SetupTC.s.sol
+++ b/script/foundry-scripts/TradingComp/SetupTC.s.sol
@@ -23,7 +23,7 @@ contract SetupTCScript is Script {
     IERC20 public cETH;
 
     bool public isProd = vm.envBool("PRODUCTION");
-    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PRECENTAGE");
+    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PERCENTAGE");
     address public ceth = vm.envAddress("WETH");
     uint256 public pk = vm.envUint("PRIVATE_KEY");
 

--- a/script/foundry-scripts/TradingComp/SlashCETH.s.sol
+++ b/script/foundry-scripts/TradingComp/SlashCETH.s.sol
@@ -6,7 +6,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract SlashCETHScript is Script {
     bool public isProd = vm.envBool("PRODUCTION");
-    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PRECENTAGE");
+    uint256 public base_redemption_fee = vm.envUint("PSM_BASE_REDEMPTION_FEE_PERCENTAGE");
     address public ceth = 0x93D16d90490d812ca6fBFD29E8eF3B31495d257D;
     uint256 public pk = vm.envUint("PRIVATE_KEY");
 

--- a/script/hardhat-scripts/deploy.ts
+++ b/script/hardhat-scripts/deploy.ts
@@ -32,10 +32,10 @@ function inferWeth() {
 }
 
 function inferBaseRedemptionFee() {
-  const fee = process.env.PSM_BASE_REDEMPTION_FEE_PRECENTAGE;
+  const fee = process.env.PSM_BASE_REDEMPTION_FEE_PERCENTAGE;
 
   if (fee == undefined || fee == "") {
-    throw new Error("PSM_BASE_REDEMPTION_FEE_PRECENTAGE not provided");
+    throw new Error("PSM_BASE_REDEMPTION_FEE_PERCENTAGE not provided");
   }
 
   return fee;

--- a/test/contracts/CorkConfig.ts
+++ b/test/contracts/CorkConfig.ts
@@ -276,13 +276,13 @@ describe("CorkConfig", function () {
     });
   });
 
-  describe("updatePsmBaseRedemptionFeePrecentage", function () {
-    it("updatePsmBaseRedemptionFeePrecentage should work correctly", async function () {
+  describe("updatePsmBaseRedemptionFeePercentage", function () {
+    it("updatePsmBaseRedemptionFeePercentage should work correctly", async function () {
       expect(await moduleCore.read.baseRedemptionFee()).to.be.equals(
         parseEther("5")
       );
       expect(
-        await corkConfig.write.updatePsmBaseRedemptionFeePrecentage([1000n], {
+        await corkConfig.write.updatePsmBaseRedemptionFeePercentage([1000n], {
           account: defaultSigner.account,
         })
       ).to.be.ok;
@@ -291,9 +291,9 @@ describe("CorkConfig", function () {
       );
     });
 
-    it("Revert when non MANAGER call updatePsmBaseRedemptionFeePrecentage", async function () {
+    it("Revert when non MANAGER call updatePsmBaseRedemptionFeePercentage", async function () {
       await expect(
-        corkConfig.write.updatePsmBaseRedemptionFeePrecentage([1000n], {
+        corkConfig.write.updatePsmBaseRedemptionFeePercentage([1000n], {
           account: secondSigner.account,
         })
       ).to.be.rejectedWith("CallerNotManager()");

--- a/test/contracts/LvCore.ts
+++ b/test/contracts/LvCore.ts
@@ -176,7 +176,7 @@ describe("LvCore", function () {
           redeemer: defaultSigner.account.address,
         })
         .then((e) => e[0]);
-      expect(event.args.feePrecentage).to.be.equal(parseEther("5"));
+      expect(event.args.feePercentage).to.be.equal(parseEther("5"));
 
       console.log(
         "event.args.amount                                          :",
@@ -229,7 +229,7 @@ describe("LvCore", function () {
           redeemer: defaultSigner.account.address,
         })
         .then((e) => e[0]);
-      expect(event.args.feePrecentage).to.be.equal(parseEther("5"));
+      expect(event.args.feePercentage).to.be.equal(parseEther("5"));
 
       expect(event.args.amount).to.be.closeTo(
         ethers.BigNumber.from(
@@ -339,7 +339,7 @@ describe("LvCore", function () {
       100
     );
     // 10% fee
-    expect(event.args.feePrecentage).to.be.equal(parseEther("5"));
+    expect(event.args.feePercentage).to.be.equal(parseEther("5"));
     // 10% fee
     expect(event.args.fee).to.be.closeTo(
       ethers.BigNumber.from(parseEther("0.05")),
@@ -355,11 +355,11 @@ describe("LvCore", function () {
       const { Id } = await issueNewSwapAssets(expiry);
 
       await moduleCore.write.depositLv([Id, depositAmount]);
-      const [rcv, fee, precentage] = await moduleCore.read.previewRedeemEarlyLv(
+      const [rcv, fee, percentage] = await moduleCore.read.previewRedeemEarlyLv(
         [Id, redeemAmount]
       );
 
-      expect(precentage).to.be.equal(parseEther("5"));
+      expect(percentage).to.be.equal(parseEther("5"));
       expect(fee).to.be.closeTo(
         ethers.BigNumber.from(parseEther("0.1")),
         // the amount of fee deducted will also slightles less because this is the first issuance,

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -118,7 +118,7 @@ describe("Module Core", function () {
       dsFlashSwapRouter.contract.address,
       univ2Router,
       config.contract.address,
-      helper.DEFAULT_BASE_REDEMPTION_PRECENTAGE,
+      helper.DEFAULT_BASE_REDEMPTION_PERCENTAGE,
     ]);
     expect(moduleCore).to.be.ok;
   });
@@ -416,26 +416,26 @@ describe("Module Core", function () {
     });
   });
 
-  describe("updatePsmBaseRedemptionFeePrecentage", function () {
-    it("updatePsmBaseRedemptionFeePrecentage should work correctly", async function () {
+  describe("updatePsmBaseRedemptionFeePercentage", function () {
+    it("updatePsmBaseRedemptionFeePercentage should work correctly", async function () {
       expect(await moduleCore.read.baseRedemptionFee()).to.equal(
         parseEther("5")
       );
-      await corkConfig.write.updatePsmBaseRedemptionFeePrecentage([500n]);
+      await corkConfig.write.updatePsmBaseRedemptionFeePercentage([500n]);
       expect(await moduleCore.read.baseRedemptionFee()).to.equal(500n);
     });
 
-    it("updatePsmBaseRedemptionFeePrecentage should revert when new value is more than 5%", async function () {
+    it("updatePsmBaseRedemptionFeePercentage should revert when new value is more than 5%", async function () {
       await expect(
-        corkConfig.write.updatePsmBaseRedemptionFeePrecentage([
+        corkConfig.write.updatePsmBaseRedemptionFeePercentage([
           parseEther("5.00000000000001"),
         ])
       ).to.be.rejectedWith("InvalidFees()");
     });
 
-    it("updatePsmBaseRedemptionFeePrecentage should revert when not called by Config contract", async function () {
+    it("updatePsmBaseRedemptionFeePercentage should revert when not called by Config contract", async function () {
       await expect(
-        moduleCore.write.updatePsmBaseRedemptionFeePrecentage([500n], {
+        moduleCore.write.updatePsmBaseRedemptionFeePercentage([500n], {
           account: secondSigner.account,
         })
       ).to.be.rejectedWith("OnlyConfigAllowed()");

--- a/test/contracts/PsmCore.ts
+++ b/test/contracts/PsmCore.ts
@@ -213,9 +213,9 @@ describe("PSM core", function () {
         .then((e) => e[0]);
 
       expect(event.args.received!).to.equal(
-        redeemAmount - helper.calculatePrecentage(redeemAmount)
+        redeemAmount - helper.calculatePercentage(redeemAmount)
       );
-      expect(event.args.fee).to.equal(helper.calculatePrecentage(redeemAmount));
+      expect(event.args.fee).to.equal(helper.calculatePercentage(redeemAmount));
     });
 
     it("should redeem DS : Approval", async function () {
@@ -438,7 +438,7 @@ describe("PSM core", function () {
 
       expect(event[0].args.dsExchangeRate).to.equal(rates);
       expect(event[0].args.received).to.equal(
-        depositAmount - helper.calculatePrecentage(depositAmount)
+        depositAmount - helper.calculatePercentage(depositAmount)
       );
     });
 
@@ -709,14 +709,14 @@ describe("PSM core", function () {
       expect(availableDs).to.equal(parseEther("10"));
 
       // remember fee rate is fixed at 10%
-      const [_, received, feePrecentage, fee, exchangeRate] =
+      const [_, received, feePercentage, fee, exchangeRate] =
         await fixture.moduleCore.read.previewRepurchase([
           fixture.Id,
           parseEther("2"),
         ]);
       
       expect(received).to.equal(parseEther("0.95"));
-      expect(feePrecentage).to.equal(parseEther("5"));
+      expect(feePercentage).to.equal(parseEther("5"));
       expect(fee).to.equal(parseEther("0.1"));
       expect(exchangeRate).to.equal(parseEther("2"));
 
@@ -732,7 +732,7 @@ describe("PSM core", function () {
       expect(event.args.received).to.equal(received);
       expect(event.args.fee).to.equal(fee);
       expect(event.args.exchangeRates).to.equal(exchangeRate);
-      expect(event.args.feePrecentage).to.equal(feePrecentage);
+      expect(event.args.feePercentage).to.equal(feePercentage);
     });
 
     it("shouldn't be able to repurchase after expired", async function () {
@@ -1122,14 +1122,14 @@ describe("PSM core", function () {
       ]);
 
       // remember fee rate is fixed at 10%
-      const [_, received, feePrecentage, fee, exchangeRate] =
+      const [_, received, feePercentage, fee, exchangeRate] =
         await fixture.moduleCore.read.previewRepurchase([
           fixture.Id,
           parseEther("2"),
         ]);
 
       expect(received).to.equal(parseEther("0.95"));
-      expect(feePrecentage).to.equal(parseEther("5"));
+      expect(feePercentage).to.equal(parseEther("5"));
       expect(fee).to.equal(parseEther("0.1"));
       expect(exchangeRate).to.equal(parseEther("2"));
     });

--- a/test/forge/Helper.sol
+++ b/test/forge/Helper.sol
@@ -86,12 +86,12 @@ abstract contract Helper is Test, SigUtils {
         Id id,
         uint256 expiryInSeconds,
         uint256 exchangeRates,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         uint256 decayDiscountRateInDays,
         uint256 rolloverPeriodInblocks
     ) internal {
         corkConfig.issueNewDs(
-            id, expiryInSeconds, exchangeRates, repurchaseFeePrecentage, decayDiscountRateInDays, rolloverPeriodInblocks
+            id, expiryInSeconds, exchangeRates, repurchaseFeePercentage, decayDiscountRateInDays, rolloverPeriodInblocks
         );
     }
 
@@ -133,7 +133,7 @@ abstract contract Helper is Test, SigUtils {
     function initializeAndIssueNewDs(
         uint256 expiryInSeconds,
         uint256 exchangeRates,
-        uint256 repurchaseFeePrecentage,
+        uint256 repurchaseFeePercentage,
         uint256 decayDiscountRateInDays,
         uint256 rolloverPeriodInblocks,
         uint256 lvFee,
@@ -147,7 +147,7 @@ abstract contract Helper is Test, SigUtils {
 
         initializeNewModuleCore(address(pa), address(ra), lvFee, initialDsPrice);
         issueNewDs(
-            id, expiryInSeconds, exchangeRates, repurchaseFeePrecentage, decayDiscountRateInDays, rolloverPeriodInblocks
+            id, expiryInSeconds, exchangeRates, repurchaseFeePercentage, decayDiscountRateInDays, rolloverPeriodInblocks
         );
     }
 

--- a/test/forge/TestFlashSwapRouter.sol
+++ b/test/forge/TestFlashSwapRouter.sol
@@ -11,8 +11,8 @@ contract TestFlashSwapRouter is RouterState {
         return reserves[id].ds[dsId];
     }
 
-    function getReserveSellPressurePrecentage(Id id) external view returns (uint256) {
-        return reserves[id].reserveSellPressurePrecentage;
+    function getReserveSellPressurePercentage(Id id) external view returns (uint256) {
+        return reserves[id].reserveSellPressurePercentage;
     }
 
     function getHpaCumulated(Id id) external view returns (uint256) {

--- a/test/forge/TestModuleCore.sol
+++ b/test/forge/TestModuleCore.sol
@@ -64,8 +64,8 @@ contract TestModuleCore is ModuleCore {
         return states[id].psm.poolArchive[dsId].rolloverProfit;
     }
 
-    function getPsmRepurchaseFeePrecentage(Id id) external view returns (uint256) {
-        return states[id].psm.repurchaseFeePrecentage;
+    function getPsmRepurchaseFeePercentage(Id id) external view returns (uint256) {
+        return states[id].psm.repurchaseFeePercentage;
     }
 
     function getPsmLiquiditySeparated(Id id, uint256 dsId) external view returns (bool) {

--- a/test/helper/TestHelper.ts
+++ b/test/helper/TestHelper.ts
@@ -18,11 +18,11 @@ import UNIV2ROUTER from "./ext-abi/hardhat/uni-v2-router.json";
 import { ethers } from "ethers";
 
 const DEVISOR = BigInt(1e18);
-export const DEFAULT_BASE_REDEMPTION_PRECENTAGE = parseEther("5");
+export const DEFAULT_BASE_REDEMPTION_PERCENTAGE = parseEther("5");
 
-export function calculatePrecentage(
+export function calculatePercentage(
   number: bigint,
-  percent: bigint = DEFAULT_BASE_REDEMPTION_PRECENTAGE
+  percent: bigint = DEFAULT_BASE_REDEMPTION_PERCENTAGE
 ) {
   return (number * DEVISOR * percent) / parseEther("100") / DEVISOR;
 }
@@ -491,7 +491,7 @@ export async function onlymoduleCoreWithFactory(basePsmRedemptionFee: bigint) {
 }
 
 export async function ModuleCoreWithInitializedPsmLv(
-  basePsmRedemptionFee: bigint = DEFAULT_BASE_REDEMPTION_PRECENTAGE
+  basePsmRedemptionFee: bigint = DEFAULT_BASE_REDEMPTION_PERCENTAGE
 ) {
   const {
     factory,

--- a/test/lib/MathHelper.ts
+++ b/test/lib/MathHelper.ts
@@ -138,7 +138,7 @@ describe("Math Helper", function () {
 
       const contract = await loadFixture(deployMathHelper);
 
-      const result = await contract.read.calculatePrecentageFee([fee, amount]);
+      const result = await contract.read.calculatePercentageFee([fee, amount]);
       expect(result).to.equal(parseEther("10"));
     });
 


### PR DESCRIPTION
### Fix variable names with typo errors
Refer this issue from sherlock audit : [sherlock issue link](https://github.com/sherlock-audit/2024-08-cork-protocol-judging/issues/271)
- [x] Fix incorrect variable and function names
- [x] Also fix same in testcases