### PR TITLE
Pause/Unpuase added for repurchase function in PSMCore 

### DIFF
--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -113,6 +113,7 @@ contract CorkConfig is AccessControl, Pausable {
      * @param id id of PSM
      * @param isPSMDepositPaused new value of isPSMDepositPaused
      * @param isPSMWithdrawalPaused new value of isPSMWithdrawalPaused
+     * @param isPSMRepurchasePaused new value of isPSMRepurchasePaused
      * @param isLVDepositPaused new value of isLVDepositPaused
      * @param isLVWithdrawalPaused new value of isLVWithdrawalPaused
      */
@@ -120,11 +121,17 @@ contract CorkConfig is AccessControl, Pausable {
         Id id,
         bool isPSMDepositPaused,
         bool isPSMWithdrawalPaused,
+        bool isPSMRepurchasePaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
     ) external onlyManager {
         moduleCore.updatePoolsStatus(
-            id, isPSMDepositPaused, isPSMWithdrawalPaused, isLVDepositPaused, isLVWithdrawalPaused
+            id,
+            isPSMDepositPaused,
+            isPSMWithdrawalPaused,
+            isPSMRepurchasePaused,
+            isLVDepositPaused,
+            isLVWithdrawalPaused
         );
     }
 

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -58,7 +58,11 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         return PairLibrary.initalize(pa, ra).toId();
     }
 
-    function initializeModuleCore(address pa, address ra, uint256 lvFee, uint256 initialDsPrice) external override onlyConfig {
+    function initializeModuleCore(address pa, address ra, uint256 lvFee, uint256 initialDsPrice)
+        external
+        override
+        onlyConfig
+    {
         Pair memory key = PairLibrary.initalize(pa, ra);
         Id id = key.toId();
 
@@ -148,15 +152,28 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         Id id,
         bool isPSMDepositPaused,
         bool isPSMWithdrawalPaused,
+        bool isPSMRepurchasePaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
     ) external onlyConfig {
         State storage state = states[id];
         PsmLibrary.updatePoolsStatus(
-            state, isPSMDepositPaused, isPSMWithdrawalPaused, isLVDepositPaused, isLVWithdrawalPaused
+            state,
+            isPSMDepositPaused,
+            isPSMWithdrawalPaused,
+            isPSMRepurchasePaused,
+            isLVDepositPaused,
+            isLVWithdrawalPaused
         );
 
-        emit PoolsStatusUpdated(id, isPSMDepositPaused, isPSMWithdrawalPaused, isLVDepositPaused, isLVWithdrawalPaused);
+        emit PoolsStatusUpdated(
+            id,
+            isPSMDepositPaused,
+            isPSMWithdrawalPaused,
+            isPSMRepurchasePaused,
+            isLVDepositPaused,
+            isLVWithdrawalPaused
+        );
     }
 
     /**

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -105,6 +105,13 @@ abstract contract ModuleState is ICommon {
         _;
     }
 
+    modifier PSMRepurchaseNotPaused(Id id) {
+        if (states[id].psm.isRepurchasePaused) {
+            revert PSMRepurchasePaused();
+        }
+        _;
+    }
+
     modifier LVDepositNotPaused(Id id) {
         if (states[id].vault.config.isWithdrawalPaused) {
             revert LVDepositPaused();

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -34,7 +34,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     function repurchase(Id id, uint256 amount)
         external
         override
-        PSMWithdrawalNotPaused(id)  
+        PSMRepurchaseNotPaused(id)
         returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates)
     {
         State storage state = states[id];
@@ -58,6 +58,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
         external
         view
         override
+        PSMRepurchaseNotPaused(id)
         returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates)
     {
         State storage state = states[id];

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -34,6 +34,7 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     function repurchase(Id id, uint256 amount)
         external
         override
+        PSMWithdrawalNotPaused(id)  
         returns (uint256 dsId, uint256 received, uint256 feePrecentage, uint256 fee, uint256 exchangeRates)
     {
         State storage state = states[id];

--- a/contracts/interfaces/ICommon.sol
+++ b/contracts/interfaces/ICommon.sol
@@ -30,6 +30,9 @@ interface ICommon {
     /// @notice PSM Withdrawal is paused, i.e thrown when withdrawal is paused for PSM
     error PSMWithdrawalPaused();
 
+    /// @notice PSM Repurchase is paused, i.e thrown when repurchase is paused for PSM
+    error PSMRepurchasePaused();
+
     /// @notice LV Deposit is paused, i.e thrown when deposit is paused for LV
     error LVDepositPaused();
 

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -114,12 +114,14 @@ interface IPSMcore is IRepurchase {
     /// @param Id The PSM id
     /// @param isPSMDepositPaused The new value saying if Deposit allowed in PSM or not
     /// @param isPSMWithdrawalPaused The new value saying if Withdrawal allowed in PSM or not
+    /// @param isPSMRepurchasePaused The new value saying if Repurcahse allowed in PSM or not
     /// @param isLVDepositPaused The new value saying if Deposit allowed in LV or not
     /// @param isLVWithdrawalPaused The new value saying if Withdrawal allowed in LV or not
     event PoolsStatusUpdated(
         Id indexed Id,
         bool isPSMDepositPaused,
         bool isPSMWithdrawalPaused,
+        bool isPSMRepurchasePaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
     );
@@ -289,7 +291,9 @@ interface IPSMcore is IRepurchase {
         external
         returns (uint256 ctReceived, uint256 dsReceived, uint256 _exchangeRate, uint256 paReceived);
 
-    function claimAutoSellProfit(Id id, uint256 prevDsId, uint256 amount) external returns (uint256 profit, uint256 dsReceived);
+    function claimAutoSellProfit(Id id, uint256 prevDsId, uint256 amount)
+        external
+        returns (uint256 profit, uint256 dsReceived);
 
     function updatePsmAutoSellStatus(Id id, address user, bool status) external;
 

--- a/contracts/interfaces/Init.sol
+++ b/contracts/interfaces/Init.sol
@@ -56,6 +56,7 @@ interface Initialize {
      * @param id id of the pair
      * @param isPSMDepositPaused set to true if you want to pause PSM deposits
      * @param isPSMWithdrawalPaused set to true if you want to pause PSM withdrawals
+     * @param isPSMRepurchasePaused set to true if you want to pause PSM repurchases
      * @param isLVDepositPaused set to true if you want to pause LV deposits
      * @param isLVWithdrawalPaused set to true if you want to pause LV withdrawals
      */
@@ -63,6 +64,7 @@ interface Initialize {
         Id id,
         bool isPSMDepositPaused,
         bool isPSMWithdrawalPaused,
+        bool isPSMRepurchasePaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
     ) external;

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -455,11 +455,13 @@ library PsmLibrary {
         State storage self,
         bool isPSMDepositPaused,
         bool isPSMWithdrawalPaused,
+        bool isPSMRepurchasePaused,
         bool isLVDepositPaused,
         bool isLVWithdrawalPaused
     ) external{
         self.psm.isDepositPaused = isPSMDepositPaused;
         self.psm.isWithdrawalPaused = isPSMWithdrawalPaused;
+        self.psm.isRepurchasePaused = isPSMRepurchasePaused;
         self.vault.config.isDepositPaused = isLVDepositPaused;
         self.vault.config.isWithdrawalPaused = isLVWithdrawalPaused;
     }

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -32,7 +32,8 @@ struct PsmState {
     mapping(address => bool) autoSell;
     bool isDepositPaused;
     bool isWithdrawalPaused;
- }
+    bool isRepurchasePaused;
+}
 
 /**
  * @dev PsmPoolArchive structure for PSM Pools
@@ -100,8 +101,8 @@ struct VaultState {
     BitMaps.BitMap lpLiquidated;
     VaultPool pool;
     uint256 initialDsPrice;
-    // will be set to true after first deposit to LV. 
-    // to prevent manipulative behavior when depositing to Lv since we depend on preview redeem eearly to get 
+    // will be set to true after first deposit to LV.
+    // to prevent manipulative behavior when depositing to Lv since we depend on preview redeem eearly to get
     // the correct exchange rate of LV
     bool initialized;
 }

--- a/test/contracts/CorkConfig.ts
+++ b/test/contracts/CorkConfig.ts
@@ -313,13 +313,20 @@ describe("CorkConfig", function () {
       const preview = 0n;
 
       expect(
-        await corkConfig.write.updatePoolsStatus([Id, true, true, true, true], {
-          account: defaultSigner.account,
-        })
+        await corkConfig.write.updatePoolsStatus(
+          [Id, true, true, true, true, true],
+          {
+            account: defaultSigner.account,
+          }
+        )
       ).to.be.ok;
 
       await expect(
         fixture.moduleCore.write.depositPsm([fixture.Id, depositAmount])
+      ).to.be.rejectedWith("PSMDepositPaused()");
+
+      await expect(
+        fixture.moduleCore.read.previewDepositPsm([fixture.Id, depositAmount])
       ).to.be.rejectedWith("PSMDepositPaused()");
 
       await expect(
@@ -331,7 +338,31 @@ describe("CorkConfig", function () {
       ).to.be.rejectedWith("PSMWithdrawalPaused()");
 
       await expect(
+        fixture.moduleCore.read.previewRedeemRaWithDs([
+          fixture.Id,
+          dsId!,
+          depositAmount,
+        ])
+      ).to.be.rejectedWith("PSMWithdrawalPaused()");
+
+      await expect(
+        fixture.moduleCore.write.repurchase([fixture.Id, depositAmount])
+      ).to.be.rejectedWith("PSMRepurchasePaused()");
+
+      await expect(
+        fixture.moduleCore.read.previewRepurchase([fixture.Id, depositAmount])
+      ).to.be.rejectedWith("PSMRepurchasePaused()");
+
+      await expect(
         fixture.moduleCore.write.redeemWithCT([
+          fixture.Id,
+          dsId!,
+          depositAmount,
+        ])
+      ).to.be.rejectedWith("PSMWithdrawalPaused()");
+
+      await expect(
+        fixture.moduleCore.read.previewRedeemWithCt([
           fixture.Id,
           dsId!,
           depositAmount,
@@ -343,7 +374,18 @@ describe("CorkConfig", function () {
       ).to.be.rejectedWith("PSMWithdrawalPaused()");
 
       await expect(
+        fixture.moduleCore.read.previewRedeemRaWithCtDs([
+          fixture.Id,
+          parseEther("2"),
+        ])
+      ).to.be.rejectedWith("PSMWithdrawalPaused()");
+
+      await expect(
         fixture.moduleCore.write.depositLv([fixture.Id, parseEther("2")])
+      ).to.be.rejectedWith("LVDepositPaused()");
+
+      await expect(
+        fixture.moduleCore.read.previewLvDeposit([fixture.Id, parseEther("2")])
       ).to.be.rejectedWith("LVDepositPaused()");
 
       await expect(
@@ -351,16 +393,26 @@ describe("CorkConfig", function () {
           fixture.Id,
           defaultSigner.account.address,
           parseEther("1"),
-          preview
+          preview,
+        ])
+      ).to.be.rejectedWith("LVWithdrawalPaused()");
+
+      await expect(
+        fixture.moduleCore.read.previewRedeemEarlyLv([
+          fixture.Id,
+          parseEther("1"),
         ])
       ).to.be.rejectedWith("LVWithdrawalPaused()");
     });
 
     it("Revert when non MANAGER call updatePoolsStatus", async function () {
       await expect(
-        corkConfig.write.updatePoolsStatus([Id, false, false, false, false], {
-          account: secondSigner.account,
-        })
+        corkConfig.write.updatePoolsStatus(
+          [Id, false, false, false, false, false],
+          {
+            account: secondSigner.account,
+          }
+        )
       ).to.be.rejectedWith("CallerNotManager()");
     });
   });

--- a/test/contracts/LvCore.ts
+++ b/test/contracts/LvCore.ts
@@ -75,7 +75,7 @@ describe("LvCore", function () {
   }
 
   async function pauseAllPools() {
-    await corkConfig.write.updatePoolsStatus([Id, true, true, true, true], {
+    await corkConfig.write.updatePoolsStatus([Id, true, true, true, true, true], {
       account: defaultSigner.account,
     });
   }

--- a/test/contracts/ModuleCore.ts
+++ b/test/contracts/ModuleCore.ts
@@ -348,6 +348,7 @@ describe("Module Core", function () {
         true,
         true,
         true,
+        true,
       ]);
       const events = await moduleCore.getEvents.PoolsStatusUpdated({
         Id: fixture.Id,
@@ -356,6 +357,7 @@ describe("Module Core", function () {
       expect(events[0].args.Id).to.equal(fixture.Id);
       expect(events[0].args.isPSMDepositPaused).to.equal(true);
       expect(events[0].args.isPSMWithdrawalPaused).to.equal(true);
+      expect(events[0].args.isPSMRepurchasePaused).to.equal(true);
       expect(events[0].args.isLVDepositPaused).to.equal(true);
       expect(events[0].args.isLVWithdrawalPaused).to.equal(true);
     });
@@ -363,7 +365,7 @@ describe("Module Core", function () {
     it("updatePoolsStatus should revert when not called by Config contract", async function () {
       await expect(
         moduleCore.write.updatePoolsStatus(
-          [fixture.Id, true, true, true, true],
+          [fixture.Id, true, true, true, true, true],
           {
             account: secondSigner.account,
           }


### PR DESCRIPTION
# Changes

List of Changes:
- added modifier check for the pause/unpause of the repurchase feature

# Notes 
- The modifier was already defined in the ModuleState by the name 'PSMDepositNotPaused(id)' 
- The isWithdrawalPaused was already being implemented in the PSMlib.sol



