### PR TITLE
Fix/symbols name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/Cork-Hook"]
 	path = lib/Cork-Hook
 	url = https://github.com/Cork-Technology/Cork-Hook
+[submodule "lib/BokkyPooBahsDateTimeLibrary"]
+	path = lib/BokkyPooBahsDateTimeLibrary
+	url = https://github.com/bokkypoobah/BokkyPooBahsDateTimeLibrary

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -162,4 +162,8 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
     function tradeExecutionFundsAvailable(Id id) external view returns (uint256) {
         return states[id].tradeExecutionFundsAvailable();
     }
+
+    function lvAsset(Id id) external view override returns (address lv) {
+        lv = states[id].vault.lv._address;
+    }
 }

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -133,4 +133,6 @@ interface IVault {
     function lvAcceptRolloverProfit(Id id, uint256 amount) external;
 
     function updateCtHeldPercentage(Id id, uint256 ctHeldPercentage) external;
+
+    function lvAsset(Id id) external view returns (address lv);
 }

--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -8,8 +8,6 @@ import {SD59x18, convert, sd, add, mul, pow, sub, div, abs, unwrap, intoUD60x18}
 import {UD60x18, convert as convertUd, ud, add, mul, pow, sub, div, unwrap} from "@prb/math/src/UD60x18.sol";
 import {IMathError} from "./../interfaces/IMathError.sol";
 import {MarketSnapshot, MarketSnapshotLib} from "Cork-Hook/lib/MarketSnapshot.sol";
-import "forge-std/console.sol";
-
 
 library BuyMathBisectionSolver {
     /// @notice returns the the normalized time to maturity from 1-0
@@ -286,8 +284,6 @@ library SwapperMathLibrary {
         UD60x18 _psmDsReserve = ud(psmDsReserve);
         UD60x18 _raProvided = ud(raProvided);
         UD60x18 _hpa = sub(convertUd(1), calcPtConstFixed(ud(hiya)));
-        console.log("hiya", hiya);
-        console.log("hpa", unwrap(_hpa));
 
         (
             UD60x18 _lvProfit,

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -205,7 +205,7 @@ library VaultLibrary {
         ratio = _determineRatio(hpa, marketRatio, self.vault.initialArp, isRollover, dsId);
     }
 
-    function _determineRatio(uint256 hpa, uint256 marketRatio, uint256 initialArp, bool isRollover, uint256 dsId)
+    function _determineRatio(uint256 hiya, uint256 marketRatio, uint256 initialArp, bool isRollover, uint256 dsId)
         internal
         pure
         returns (uint256 ratio)
@@ -213,16 +213,17 @@ library VaultLibrary {
         // fallback to initial ds price ratio if hpa is 0, and market ratio is 0
         // usually happens when there's no trade on the router AND is not the first issuance
         // OR it's the first issuance
-        if (hpa == 0 && marketRatio == 0) {
+        if (hiya == 0 && marketRatio == 0) {
             // TODO : test vault initialization works
             ratio = MathHelper.calculateInitialCtRatio(initialArp);
             return ratio;
         }
 
-        // this will return the hpa as ratio when it's basically not the first issuance, and there's actually an hpa to rely on
+        // this will return the hiya as hpa as ratio when it's basically not the first issuance, and there's actually an hiya to rely on
         // we must specifically check for market ratio since, we want to trigger this only when there's no market ratio(i.e freshly after a rollover)
-        if (dsId != 1 && isRollover && hpa != 0 && marketRatio == 0) {
-            ratio = hpa;
+        if (dsId != 1 && isRollover && hiya != 0 && marketRatio == 0) {
+            // we add 2 zerom since the function will normalize it to 0-1 from 1-100
+            ratio = MathHelper.calculateInitialCtRatio(hiya * 100);
             return ratio;
         }
 
@@ -655,9 +656,7 @@ library VaultLibrary {
         self.vault.balances.ra.unlockToUnchecked(result.raReceivedFromAmm, owner);
 
         // send CT received from AMM and held in vault to user
-        SafeERC20.safeTransfer(
-            IERC20(ds.ct), owner, result.ctReceivedFromVault + result.ctReceivedFromAmm
-        );
+        SafeERC20.safeTransfer(IERC20(ds.ct), owner, result.ctReceivedFromVault + result.ctReceivedFromAmm);
 
         // empty the DS reserve in router and send it to user
         routers.flashSwapRouter.emptyReservePartialLv(redeemParams.id, dsId, result.dsReceived);

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,6 @@ test = "test"
 cache_path = "cache_forge"
 ffi = true
 optimizer = true
-optimizer_runs = 1_000_000
+optimizer_runs = 200
 solc_version = "0.8.26"
 fs_permissions = [{ access = "read", path = "./"}]

--- a/remappings.txt
+++ b/remappings.txt
@@ -20,3 +20,4 @@ v2-periphery/=lib/Cork-Hook/lib/Depeg-swap/lib/v2-periphery/contracts/
 v4-core/=lib/Cork-Hook/lib/v4-periphery/lib/v4-core/src/
 v4-periphery/=lib/Cork-Hook/lib/v4-periphery/
 @prb/math/=lib/prb-math/
+BokkyPooBahsDateTimeLibrary/=lib/BokkyPooBahsDateTimeLibrary/contracts/


### PR DESCRIPTION
# Changes
closes #218 

List of Changes:
- now symbol and name is underyling RA PA combined with expiry
- fix precision issue that caused the rollover sale to fail
- fix initialization value where the HIYA is rounded to 0-1 twice

