### PR TITLE
Feat/offchain guess

### DIFF
--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -419,9 +419,10 @@ contract CorkConfig is AccessControl, Pausable {
         address hedgeUnit,
         uint256 amount,
         uint256 amountOutMin,
-        IDsFlashSwapCore.BuyAprroxParams calldata params
+        IDsFlashSwapCore.BuyAprroxParams calldata params,
+        IDsFlashSwapCore.OffchainGuess calldata offchainGuess
     ) external onlyManager returns (uint256 amountOut) {
-        amountOut = HedgeUnit(hedgeUnit).useFunds(amount, amountOutMin, params);
+        amountOut = HedgeUnit(hedgeUnit).useFunds(amount, amountOutMin, params, offchainGuess);
     }
 
     /**

--- a/contracts/core/flash-swaps/FlashSwapRouter.sol
+++ b/contracts/core/flash-swaps/FlashSwapRouter.sol
@@ -270,13 +270,10 @@ contract RouterState is
         uint256 dsId,
         uint256 amount,
         uint256 amountOutMin,
-        IDsFlashSwapCore.BuyAprroxParams memory approxParams
-    ) internal {
-        // we convert it first to 18 decimals, all transfers must use transferHelper library
-
-        // amount = TransferHelper.tokenNativeDecimalsToFixed(amount, assetPair.ra);
-
-        uint256 borrowedAmount;
+        IDsFlashSwapCore.BuyAprroxParams memory approxParams,
+        IDsFlashSwapCore.OffchainGuess memory offchainGuess
+    ) internal returns (uint256 initialBorrowedAmount, uint256 finalBorrowedAmount) {
+        finalBorrowedAmount;
 
         uint256 dsReceived;
         // try to swap the RA for DS via rollover, this will noop if the condition for rollover is not met
@@ -288,27 +285,30 @@ contract RouterState is
             // there's no possibility of selling the reserve, hence no chance of mix-up of return value
             ReturnDataSlotLib.increase(ReturnDataSlotLib.RETURN_SLOT, dsReceived);
 
-            return;
+            return (0, 0);
         }
 
         uint256 amountOut;
 
-        // calculate the amount of DS tokens attributed
-        (amountOut, borrowedAmount) = assetPair.getAmountOutBuyDS(amount, hook, approxParams);
-
-        // calculate the amount of DS tokens that will be sold from reserve
-
-        uint256 amountSellFromReserve = calculateSellFromReserve(self, amountOut, dsId);
-
-        // sell the DS tokens from the reserve if there's any
-        if (amountSellFromReserve > RESERVE_MINIMUM_SELL_AMOUNT && !self.gradualSaleDisabled) {
-            SellResult memory sellDsReserveResult =
-                _sellDsReserve(assetPair, SellDsParams(reserveId, dsId, amountSellFromReserve, amount, approxParams));
-
-            if (sellDsReserveResult.success) {
-                borrowedAmount = sellDsReserveResult.borrowedAmount;
-            }
+        if (offchainGuess.initialBorrowAmount == 0) {
+            // calculate the amount of DS tokens attributed
+            (amountOut, finalBorrowedAmount) = assetPair.getAmountOutBuyDS(amount, hook, approxParams);
+            initialBorrowedAmount = finalBorrowedAmount;
+        } else {
+            // we convert the amount to fixed point 18 decimals since, the amount out will be DS, and DS is always 18 decimals.
+            amountOut =
+                TransferHelper.tokenNativeDecimalsToFixed(offchainGuess.initialBorrowAmount + amount, assetPair.ra);
+            finalBorrowedAmount = offchainGuess.initialBorrowAmount;
+            initialBorrowedAmount = offchainGuess.initialBorrowAmount;
         }
+
+        finalBorrowedAmount = calculateAndSellDsReserve(
+            self,
+            assetPair,
+            CalculateAndSellDsParams(
+                reserveId, dsId, amount, approxParams, offchainGuess, finalBorrowedAmount, amountOut
+            )
+        );
 
         // increase the return data slot value with DS that the user got from rollover sale
         // the reason we do this after selling the DS reserve is to prevent mix-up of return value
@@ -317,12 +317,47 @@ contract RouterState is
         ReturnDataSlotLib.clear(ReturnDataSlotLib.RETURN_SLOT);
         ReturnDataSlotLib.increase(ReturnDataSlotLib.RETURN_SLOT, dsReceived);
 
-        // convert to native token decimals
-        // borrowedAmount = TransferHelper.fixedToTokenNativeDecimals(borrowedAmount, assetPair.ra);
-        // amount = TransferHelper.fixedToTokenNativeDecimals(amount, assetPair.ra);
-
         // trigger flash swaps and send the attributed DS tokens to the user
-        __flashSwap(assetPair, borrowedAmount, 0, dsId, reserveId, true, msg.sender, amount);
+        __flashSwap(assetPair, finalBorrowedAmount, 0, dsId, reserveId, true, msg.sender, amount);
+    }
+
+    struct CalculateAndSellDsParams {
+        Id reserveId;
+        uint256 dsId;
+        uint256 amount;
+        IDsFlashSwapCore.BuyAprroxParams approxParams;
+        IDsFlashSwapCore.OffchainGuess offchainGuess;
+        uint256 initialBorrowedAmount;
+        uint256 initialAmountOut;
+    }
+
+    function calculateAndSellDsReserve(
+        ReserveState storage self,
+        AssetPair storage assetPair,
+        CalculateAndSellDsParams memory params
+    ) internal returns (uint256 borrowedAmount) {
+        // calculate the amount of DS tokens that will be sold from reserve
+        uint256 amountSellFromReserve = calculateSellFromReserve(self, params.initialAmountOut, params.dsId);
+
+        if (amountSellFromReserve < RESERVE_MINIMUM_SELL_AMOUNT || self.gradualSaleDisabled) {
+            return params.initialBorrowedAmount;
+        }
+
+        bool success = _sellDsReserve(
+            assetPair,
+            SellDsParams(params.reserveId, params.dsId, amountSellFromReserve, params.amount, params.approxParams)
+        );
+
+        if (!success) {
+            return params.initialBorrowedAmount;
+        }
+
+        // we calculate the borrowed amount if user doesn't supply offchain guess
+        if (params.offchainGuess.afterSoldBorrowAmount == 0) {
+            (, borrowedAmount) = assetPair.getAmountOutBuyDS(params.amount, hook, params.approxParams);
+        } else {
+            borrowedAmount = params.offchainGuess.afterSoldBorrowAmount;
+        }
     }
 
     function calculateSellFromReserve(ReserveState storage self, uint256 amountOut, uint256 dsId)
@@ -356,19 +391,16 @@ contract RouterState is
         bool success;
     }
 
-    function _sellDsReserve(AssetPair storage assetPair, SellDsParams memory params)
-        internal
-        returns (SellResult memory result)
-    {
+    function _sellDsReserve(AssetPair storage assetPair, SellDsParams memory params) internal returns (bool success) {
+        uint256 profitRa;
+
         // sell the DS tokens from the reserve and accrue value to LV holders
         // it's safe to transfer all profit to the module core since the profit for each PSM and LV is calculated separately and we invoke
         // the profit acceptance function for each of them
         //
         // this function can fail, if there's not enough CT liquidity to sell the DS tokens, in that case, we skip the selling part and let user buy the DS tokens
-        (uint256 profitRa, bool success) =
+        (profitRa, success) =
             __swapDsforRa(assetPair, params.reserveId, params.dsId, params.amountSellFromReserve, 0, _moduleCore);
-
-        result.success = success;
 
         if (success) {
             uint256 lvReserve = assetPair.lvReserve;
@@ -376,7 +408,6 @@ contract RouterState is
 
             // calculate the amount of DS tokens that will be sold from both reserve
             uint256 lvReserveUsed = lvReserve * params.amountSellFromReserve * 1e18 / (totalReserve) / 1e18;
-            // uint256 psmReserveUsed = amountSellFromReserve - lvReserveUsed;
 
             // decrement reserve
             assetPair.lvReserve -= lvReserveUsed;
@@ -389,10 +420,6 @@ contract RouterState is
             IVault(_moduleCore).provideLiquidityWithFlashSwapFee(params.reserveId, vaultProfit);
             // send profit to the PSM
             IPSMcore(_moduleCore).psmAcceptFlashSwapProfit(params.reserveId, profitRa - vaultProfit);
-
-            // recalculate the amount of DS tokens attributed, since we sold some from the reserve
-            (result.amountOut, result.borrowedAmount) =
-                assetPair.getAmountOutBuyDS(params.amount, hook, params.approxParams);
         }
     }
 
@@ -404,8 +431,9 @@ contract RouterState is
         address user,
         bytes memory rawRaPermitSig,
         uint256 deadline,
-        BuyAprroxParams memory params
-    ) external autoClearReturnData returns (uint256 amountOut, uint256 ctRefunded) {
+        BuyAprroxParams memory params,
+        OffchainGuess memory offchainGuess
+    ) external autoClearReturnData returns (SwapRaForDsReturn memory result) {
         if (rawRaPermitSig.length == 0 || deadline == 0) {
             revert InvalidSignature();
         }
@@ -419,57 +447,54 @@ contract RouterState is
         DepegSwapLibrary.permitForRA(address(assetPair.ra), rawRaPermitSig, user, address(this), amount, deadline);
         IERC20(assetPair.ra).safeTransferFrom(user, address(this), amount);
 
-        _swapRaforDs(self, assetPair, reserveId, dsId, amount, amountOutMin, params);
+        (result.initialBorrow, result.afterSoldBorrow) =
+            _swapRaforDs(self, assetPair, reserveId, dsId, amount, amountOutMin, params, offchainGuess);
+
+        result.amountOut = ReturnDataSlotLib.get(ReturnDataSlotLib.RETURN_SLOT);
 
         // slippage protection, revert if the amount of DS tokens received is less than the minimum amount
-        if (amountOut < amountOutMin) {
+        if (result.amountOut < amountOutMin) {
             revert InsufficientOutputAmount();
         }
 
-        amountOut = ReturnDataSlotLib.get(ReturnDataSlotLib.RETURN_SLOT);
-        ctRefunded = ReturnDataSlotLib.get(ReturnDataSlotLib.REFUNDED_SLOT);
+        result.ctRefunded = ReturnDataSlotLib.get(ReturnDataSlotLib.REFUNDED_SLOT);
 
-        self.recalculateHIYA(dsId, TransferHelper.tokenNativeDecimalsToFixed(amount, assetPair.ra), amountOut);
+        self.recalculateHIYA(dsId, TransferHelper.tokenNativeDecimalsToFixed(amount, assetPair.ra), result.amountOut);
 
-        emit RaSwapped(reserveId, dsId, user, amount, amountOut, ctRefunded);
+        emit RaSwapped(reserveId, dsId, user, amount, result.amountOut, result.ctRefunded);
     }
 
-    /**
-     * @notice Swaps RA for DS
-     * @param reserveId the reserve id same as the id on PSM and LV
-     * @param dsId the ds id of the pair, the same as the DS id on PSM and LV
-     * @param amount the amount of RA to swap
-     * @param amountOutMin the minimum amount of DS to receive, will revert if the actual amount is less than this. should be inserted with value from previewSwapRaforDs
-     * @return amountOut amount of DS that's received
-     */
     function swapRaforDs(
         Id reserveId,
         uint256 dsId,
         uint256 amount,
         uint256 amountOutMin,
-        BuyAprroxParams memory params
-    ) external autoClearReturnData returns (uint256 amountOut, uint256 ctRefunded) {
+        BuyAprroxParams memory params,
+        OffchainGuess memory offchainGuess
+    ) external autoClearReturnData returns (SwapRaForDsReturn memory result) {
         ReserveState storage self = reserves[reserveId];
         AssetPair storage assetPair = self.ds[dsId];
 
         IERC20(assetPair.ra).safeTransferFrom(msg.sender, address(this), amount);
 
-        _swapRaforDs(self, assetPair, reserveId, dsId, amount, amountOutMin, params);
+        (result.initialBorrow, result.afterSoldBorrow) =
+            _swapRaforDs(self, assetPair, reserveId, dsId, amount, amountOutMin, params, offchainGuess);
+
+        result.amountOut = ReturnDataSlotLib.get(ReturnDataSlotLib.RETURN_SLOT);
 
         // slippage protection, revert if the amount of DS tokens received is less than the minimum amount
-        if (amountOut < amountOutMin) {
+        if (result.amountOut < amountOutMin) {
             revert InsufficientOutputAmount();
         }
 
-        amountOut = ReturnDataSlotLib.get(ReturnDataSlotLib.RETURN_SLOT);
-        ctRefunded = ReturnDataSlotLib.get(ReturnDataSlotLib.REFUNDED_SLOT);
+        result.ctRefunded = ReturnDataSlotLib.get(ReturnDataSlotLib.REFUNDED_SLOT);
 
-        self.recalculateHIYA(dsId, TransferHelper.tokenNativeDecimalsToFixed(amount, assetPair.ra), amountOut);
+        self.recalculateHIYA(dsId, TransferHelper.tokenNativeDecimalsToFixed(amount, assetPair.ra), result.amountOut);
 
-        emit RaSwapped(reserveId, dsId, msg.sender, amount, amountOut, ctRefunded);
+        emit RaSwapped(reserveId, dsId, msg.sender, amount, result.amountOut, result.ctRefunded);
     }
 
-    function isRolloverSale(Id id, uint256 dsId) external view returns (bool) {
+    function isRolloverSale(Id id) external view returns (bool) {
         return reserves[id].rolloverSale();
     }
 

--- a/contracts/core/liquidators/cow-protocol/Liquidator.sol
+++ b/contracts/core/liquidators/cow-protocol/Liquidator.sol
@@ -169,14 +169,16 @@ contract Liquidator is ILiquidator {
     function finishHedgeUnitOrderAndExecuteTrade(
         bytes32 refId,
         uint256 amountOutMin,
-        IDsFlashSwapCore.BuyAprroxParams calldata params
+        IDsFlashSwapCore.BuyAprroxParams calldata params,
+        IDsFlashSwapCore.OffchainGuess calldata offchainGuess
     ) external onlyLiquidator returns (uint256 amountOut) {
         Orders memory order = orderCalls[refId];
 
         (uint256 funds,) = HedgeUnitChildLiquidator(order.liquidator).moveFunds();
 
         // we don't want to revert if the trade fails
-        try HedgeUnit(order.receiver).useFunds(funds, amountOutMin, params) returns (uint256 _amountOut) {
+        try HedgeUnit(order.receiver).useFunds(funds, amountOutMin, params, offchainGuess) returns (uint256 _amountOut)
+        {
             amountOut = _amountOut;
         } catch {}
 

--- a/contracts/interfaces/IDsFlashSwapRouter.sol
+++ b/contracts/interfaces/IDsFlashSwapRouter.sol
@@ -106,8 +106,8 @@ interface IDsFlashSwapCore is IDsFlashSwapUtility {
         uint256 precisionBufferPercentage;
     }
 
-    /// @notice offchain guess for CT AMM borrowing used in swapping RA for DS.
-    /// if empty, the router will try and calculate the optimal amount of CT to borrow
+    /// @notice offchain guess for RA AMM borrowing used in swapping RA for DS.
+    /// if empty, the router will try and calculate the optimal amount of RA to borrow
     /// using this will greatly reduce the gas cost.
     /// will be the default way to swap RA for DS
     struct OffchainGuess {

--- a/contracts/interfaces/IHedgeUnitLiquidation.sol
+++ b/contracts/interfaces/IHedgeUnitLiquidation.sol
@@ -22,9 +22,12 @@ interface IHedgeUnitLiquidation {
 
     /// @notice Use funds from liquidation, the Hedge Unit will use the received funds to buy DS
     /// IMPORTANT : the Hedge Unit must make sure only the config contract can call this function, that in turns only can be called by the config contract manager
-    function useFunds(uint256 amount, uint256 amountOutMin, IDsFlashSwapCore.BuyAprroxParams calldata params)
-        external
-        returns (uint256 amountOut);
+    function useFunds(
+        uint256 amount,
+        uint256 amountOutMin,
+        IDsFlashSwapCore.BuyAprroxParams calldata params,
+        IDsFlashSwapCore.OffchainGuess calldata offchainGuess
+    ) external returns (uint256 amountOut);
 
     /// @notice Returns the amount of funds available for liquidation or trading
     /// @param token The token to check, must be either RA or PA in the contract, will fail otherwise

--- a/contracts/libraries/DsFlashSwap.sol
+++ b/contracts/libraries/DsFlashSwap.sol
@@ -235,8 +235,6 @@ library DsFlashSwaplibrary {
             InitialTradeCaclParams(market.reserveRa, market.reserveCt, issuedAt, end, amount, params)
         );
 
-        // amountOut = TransferHelper.fixedToTokenNativeDecimals(amountOut, assetPair.ra);
-        // market.reserveRa = TransferHelper.fixedToTokenNativeDecimals(market.reserveRa, assetPair.ra);
         // we subtract some percentage of it to account for dust imprecisions
         amountOut -= SwapperMathLibrary.calculatePercentage(amountOut, params.precisionBufferPercentage);
 

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -227,7 +227,7 @@ library VaultLibrary {
     {
         Id id = self.info.toId();
         uint256 hpa = flashSwapRouter.getCurrentEffectiveHIYA(id);
-        bool isRollover = flashSwapRouter.isRolloverSale(id, dsId);
+        bool isRollover = flashSwapRouter.isRolloverSale(id);
 
         uint256 marketRatio;
 

--- a/test/forge/FlashSwap.t.sol
+++ b/test/forge/FlashSwap.t.sol
@@ -54,7 +54,11 @@ contract FlashSwapTest is Helper {
 
         ra.approve(address(flashSwapRouter), type(uint256).max);
 
-        (uint256 amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        IDsFlashSwapCore.SwapRaForDsReturn memory result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+
+        uint256 amountOut = result.amountOut;
 
         IPSMcore(moduleCore).updatePsmAutoSellStatus(currencyId, true);
 
@@ -64,7 +68,12 @@ contract FlashSwapTest is Helper {
 
         // should work, even though there's insfuicient liquidity to sell the LV reserves
         uint256 lvReserveBefore = flashSwapRouter.getLvReserve(currencyId, dsId);
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 100 ether, 0, defaultBuyApproxParams());
+
+        result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 100 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        amountOut = result.amountOut;
+
         uint256 lvReserveAfter = flashSwapRouter.getLvReserve(currencyId, dsId);
 
         vm.assertEq(lvReserveBefore, lvReserveAfter);
@@ -81,7 +90,9 @@ contract FlashSwapTest is Helper {
 
         // now if buy, it should sell from reserves
         lvReserveBefore = flashSwapRouter.getLvReserve(currencyId, dsId);
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 10 ether, 0, defaultBuyApproxParams());
+        result = flashSwapRouter.swapRaforDs(currencyId, dsId, 10 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams());
+        amountOut = result.amountOut;
+
         lvReserveAfter = flashSwapRouter.getLvReserve(currencyId, dsId);
 
         vm.assertTrue(lvReserveAfter < lvReserveBefore);

--- a/test/forge/Rollover.t.sol
+++ b/test/forge/Rollover.t.sol
@@ -147,7 +147,11 @@ contract RolloverTest is Helper {
         uint256 expiry = Asset(ds).expiry();
         vm.warp(expiry - 100);
 
-        (uint256 amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        IDsFlashSwapCore.SwapRaForDsReturn memory result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        uint256 amountOut = result.amountOut;
+
         uint256 HiyaCummulated = flashSwapRouter.getHiyaCumulated(currencyId);
         uint256 vHiyaCummulated = flashSwapRouter.getVhiyaCumulated(currencyId);
 
@@ -170,7 +174,10 @@ contract RolloverTest is Helper {
         // we autosell
         vm.assertEq(dsReceived, 0);
 
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        amountOut = result.amountOut;
 
         uint256 rolloverProfit = moduleCore.getPsmPoolArchiveRolloverProfit(currencyId, dsId);
         vm.assertNotEq(rolloverProfit, 0);
@@ -214,7 +221,11 @@ contract RolloverTest is Helper {
         uint256 expiry = Asset(ds).expiry();
         vm.warp(expiry - 100);
 
-        (uint256 amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        IDsFlashSwapCore.SwapRaForDsReturn memory result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        uint256 amountOut = result.amountOut;
+
         uint256 HiyaCummulated = flashSwapRouter.getHiyaCumulated(currencyId);
         uint256 vHiyaCummulated = flashSwapRouter.getVhiyaCumulated(currencyId);
 
@@ -237,7 +248,8 @@ contract RolloverTest is Helper {
         // we autosell
         vm.assertEq(dsReceived, 0);
 
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        result = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams());
+        amountOut = result.amountOut;
 
         uint256 rolloverProfit = moduleCore.getPsmPoolArchiveRolloverProfit(currencyId, dsId);
         vm.assertNotEq(rolloverProfit, 0);
@@ -264,7 +276,10 @@ contract RolloverTest is Helper {
         uint256 expiry = Asset(ds).expiry();
         vm.warp(expiry - 100);
 
-        (uint256 amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        IDsFlashSwapCore.SwapRaForDsReturn memory result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        uint256 amountOut = result.amountOut;
 
         uint256 HiyaCummulated = flashSwapRouter.getHiyaCumulated(currencyId);
         uint256 vHiyaCummulated = flashSwapRouter.getVhiyaCumulated(currencyId);
@@ -288,7 +303,7 @@ contract RolloverTest is Helper {
         // we autosell
         vm.assertEq(dsReceived, 0);
 
-        vm.assertEq(true, flashSwapRouter.isRolloverSale(currencyId, dsId));
+        vm.assertEq(true, flashSwapRouter.isRolloverSale(currencyId));
 
         // based on the Hiya = 0.017895624717812529 (~1% ARP) and t = 1
         uint256 expectedHPA = 0.017895624717812529 ether;
@@ -296,11 +311,17 @@ contract RolloverTest is Helper {
         // we disable graduale sale to get an accurate representation
         disableDsGradualSale();
 
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, expectedHPA, 0, defaultBuyApproxParams());
+        result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, expectedHPA, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        amountOut = result.amountOut;
 
         vm.assertApproxEqAbs(amountOut, 1 ether, 0.018 ether);
 
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, expectedHPA * 10, 0, defaultBuyApproxParams());
+        result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, expectedHPA * 10, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        amountOut = result.amountOut;
 
         vm.assertApproxEqAbs(amountOut, 10 ether, 0.18 ether);
     }
@@ -314,7 +335,11 @@ contract RolloverTest is Helper {
         uint256 expiry = Asset(ds).expiry();
         vm.warp(expiry - 100);
 
-        (uint256 amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, 1 ether, 0, defaultBuyApproxParams());
+        IDsFlashSwapCore.SwapRaForDsReturn memory result = flashSwapRouter.swapRaforDs(
+            currencyId, dsId, 1 ether, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
+        uint256 amountOut = result.amountOut;
+
         uint256 HiyaCummulated = flashSwapRouter.getHiyaCumulated(currencyId);
         uint256 vHiyaCummulated = flashSwapRouter.getVhiyaCumulated(currencyId);
 
@@ -337,9 +362,11 @@ contract RolloverTest is Helper {
         // we autosell
         vm.assertEq(dsReceived, 0);
 
-        vm.assertEq(true, flashSwapRouter.isRolloverSale(currencyId, dsId));
+        vm.assertEq(true, flashSwapRouter.isRolloverSale(currencyId));
 
         vm.expectRevert();
-        (amountOut,) = flashSwapRouter.swapRaforDs(currencyId, dsId, Hiya, 1000000 ether, defaultBuyApproxParams());
+        flashSwapRouter.swapRaforDs(
+            currencyId, dsId, Hiya, 1000000 ether, defaultBuyApproxParams(), defaultOffchainGuessParams()
+        );
     }
 }

--- a/test/forge/integration/hedgeUnit/LiquidityFunds.t.sol
+++ b/test/forge/integration/hedgeUnit/LiquidityFunds.t.sol
@@ -121,7 +121,7 @@ contract HedgeUnitTest is Helper {
 
         uint256 dsBalanceBefore = dsToken.balanceOf(address(hedgeUnit));
         uint256 amountOut =
-            corkConfig.buyDsFromHedgeUnit(address(hedgeUnit), requestAmount, 0, defaultBuyApproxParams());
+            corkConfig.buyDsFromHedgeUnit(address(hedgeUnit), requestAmount, 0, defaultBuyApproxParams(), defaultOffchainGuessParams());
 
         uint256 dsBalanceAfter = dsToken.balanceOf(address(hedgeUnit));
 

--- a/test/forge/integration/liquidation/HedgeUnitLiquidation.t.sol
+++ b/test/forge/integration/liquidation/HedgeUnitLiquidation.t.sol
@@ -204,7 +204,7 @@ contract HedgeUnitTest is Helper {
         uint256 raBalanceHedgeUnitBefore = ra.balanceOf(address(hedgeUnit));
         uint256 dsBalanceHedgeUnitBefore = dsToken.balanceOf(address(hedgeUnit));
 
-        uint256 dsBought = liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 0, defaultBuyApproxParams());
+        uint256 dsBought = liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 0, defaultBuyApproxParams(), defaultOffchainGuessParams());
 
         uint256 paBalanceHedgeUnitAfter = pa.balanceOf(address(hedgeUnit));
         uint256 raBalanceHedgeUnitAfter = ra.balanceOf(address(hedgeUnit));
@@ -247,7 +247,7 @@ contract HedgeUnitTest is Helper {
         uint256 dsBalanceHedgeUnitBefore = dsToken.balanceOf(address(hedgeUnit));
 
         uint256 dsBought =
-            liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 10000000 ether, defaultBuyApproxParams());
+            liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 10000000 ether, defaultBuyApproxParams(), defaultOffchainGuessParams());
         vm.assertEq(dsBought, 0);
 
         uint256 paBalanceHedgeUnitAfter = pa.balanceOf(address(hedgeUnit));
@@ -280,6 +280,6 @@ contract HedgeUnitTest is Helper {
         liquidator.createOrderHedgeUnit(params);
 
         vm.expectRevert();
-        liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 10000000 ether, defaultBuyApproxParams());
+        liquidator.finishHedgeUnitOrderAndExecuteTrade(randomRefId, 10000000 ether, defaultBuyApproxParams(), defaultOffchainGuessParams());
     }
 }


### PR DESCRIPTION
# Changes

List of Changes:
 - BREAKING : added offchain guess parameters in swap RA for DS
 - BREAKING : remove early redemption fee related codes
 
 # Notes
  ```solidity
     struct SwapRaForDsReturn {
        uint256 amountOut;
        uint256 ctRefunded;
        /// @dev the amount of RA that needs to be borrowed on first iteration, this amount + user supplied / 2 of DS
        /// will be sold from the reserve unless it doesn't met the minimum amount, the DS reserve is empty,
        /// or the DS reserve sale is disabled. in such cases, this will be the final amount of RA that's borrowed
        /// and the "afterSoldBorrow" will be 0.
        /// if the swap is fully fullfilled by the rollover sale, both initialBorrow and afterSoldBorrow will be 0
        uint256 initialBorrow; <- return this
        /// @dev the final amount of RA that's borrowed after selling DS reserve
        uint256 afterSoldBorrow; <- also this
    }

 ```
 - backend should return `initialBorrow` and `afterSoldBorrow` to frontend after running the preview to be used as offchain guess parameters. cc @FocusBT  @Shirku 
 
 ```solidity
  /// @notice offchain guess for RA AMM borrowing used in swapping RA for DS.
    /// if empty, the router will try and calculate the optimal amount of RA to borrow
    /// using this will greatly reduce the gas cost.
    /// will be the default way to swap RA for DS
    struct OffchainGuess {
        uint256 initialBorrowAmount;
        uint256 afterSoldBorrowAmount;
    }
 ```
