### PR TITLE
Feat/minor adjustment

### DIFF
--- a/contracts/core/CorkConfig.sol
+++ b/contracts/core/CorkConfig.sol
@@ -420,12 +420,8 @@ contract CorkConfig is AccessControl, Pausable {
     }
 
     function updatePsmRate(Id id, uint256 newRate) external onlyUpdaterOrManager {
-        // we update the rate in our provider regardless it's up or down
+        // we update the rate in our provider regardless it's up or down. won't affect other market's rates that doesn't use this provider
         defaultExchangeRateProvider.setRate(id, newRate);
-
-        // we don't bubble up the error since if this is a yield bearing PA, then the value of PA goes up
-        // but we don't want to insure the yield, so we just ignore the error
-        try moduleCore.updateRate(id, newRate) {} catch {}
     }
 
     function useVaultTradeExecutionResultFunds(Id id) external onlyManager {

--- a/contracts/core/ExchangeRateProvider.sol
+++ b/contracts/core/ExchangeRateProvider.sol
@@ -5,7 +5,7 @@ import {Id, Pair, PairLibrary} from "../libraries/Pair.sol";
 import {IErrors} from "./../interfaces/IErrors.sol";
 import {MathHelper} from "./../libraries/MathHelper.sol";
 import {IExchangeRateProvider} from "./../interfaces/IExchangeRateProvider.sol";
-import {DepegSwapLibrary}from"./../libraries/DepegSwapLib.sol";
+import {DepegSwapLibrary} from "./../libraries/DepegSwapLib.sol";
 
 /**
  * @title ExchangeRateProvider Contract

--- a/contracts/core/ExchangeRateProvider.sol
+++ b/contracts/core/ExchangeRateProvider.sol
@@ -5,6 +5,7 @@ import {Id, Pair, PairLibrary} from "../libraries/Pair.sol";
 import {IErrors} from "./../interfaces/IErrors.sol";
 import {MathHelper} from "./../libraries/MathHelper.sol";
 import {IExchangeRateProvider} from "./../interfaces/IExchangeRateProvider.sol";
+import {DepegSwapLibrary}from"./../libraries/DepegSwapLib.sol";
 
 /**
  * @title ExchangeRateProvider Contract
@@ -51,5 +52,20 @@ contract ExchangeRateProvider is IErrors, IExchangeRateProvider {
         onlyConfig();
 
         exchangeRate[id] = newRate;
+    }
+
+    function _ensureRateIsInDeltaRange(uint256 currentRate, uint256 newRate) internal {
+        // rate must never go higher than the current rate
+        if (newRate > currentRate) {
+            revert IErrors.InvalidRate();
+        }
+
+        uint256 delta = MathHelper.calculatePercentageFee(DepegSwapLibrary.MAX_RATE_DELTA_PERCENTAGE, currentRate);
+        delta = currentRate - delta;
+
+        // rate must never go down below delta
+        if (newRate < delta) {
+            revert IErrors.InvalidRate();
+        }
     }
 }

--- a/contracts/core/ExchangeRateProvider.sol
+++ b/contracts/core/ExchangeRateProvider.sol
@@ -53,19 +53,4 @@ contract ExchangeRateProvider is IErrors, IExchangeRateProvider {
 
         exchangeRate[id] = newRate;
     }
-
-    function _ensureRateIsInDeltaRange(uint256 currentRate, uint256 newRate) internal {
-        // rate must never go higher than the current rate
-        if (newRate > currentRate) {
-            revert IErrors.InvalidRate();
-        }
-
-        uint256 delta = MathHelper.calculatePercentageFee(DepegSwapLibrary.MAX_RATE_DELTA_PERCENTAGE, currentRate);
-        delta = currentRate - delta;
-
-        // rate must never go down below delta
-        if (newRate < delta) {
-            revert IErrors.InvalidRate();
-        }
-    }
 }

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -121,10 +121,9 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
 
         Pair storage info = state.info;
 
-        // we update the rate, if this is a yield bearing PA then the rate should go up
-        // this works since if the market uses our rate provider, then when updating the rate and the rate goes up
-        // the function would revert, but catched on the config contract, resulting in the provider also updating the rate accordingly that's used here
-        uint256 exchangeRates = _getRate(id, info);
+        // we update the rate, if this is a yield bearing PA then the rate should go up.
+        // that's why there's no check that prevents the rate from going up.
+        uint256 exchangeRates = PsmLibrary._getLatestRate(state);
 
         (address ct, address ds) = IAssetFactory(SWAP_ASSET_FACTORY).deploySwapAssets(
             IAssetFactory.DeployParams(

--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -105,7 +105,7 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         PsmLibrary.initialize(state, key);
         VaultLibrary.initialize(state.vault, lv, ra, initialArp);
 
-        emit InitializedModuleCore(id, pa, ra, lv, expiryInterval);
+        emit InitializedModuleCore(id, pa, ra, lv, expiryInterval, initialArp, exchangeRateProvider);
     }
 
     function issueNewDs(

--- a/contracts/core/Psm.sol
+++ b/contracts/core/Psm.sol
@@ -18,26 +18,6 @@ abstract contract PsmCore is IPSMcore, ModuleState, Context {
     using PsmLibrary for State;
     using PairLibrary for Pair;
 
-    function updateRate(Id id, uint256 newRate) external {
-        onlyConfig();
-        State storage state = states[id];
-        uint256 previousRate = state.exchangeRate();
-
-        state.updateExchangeRate(newRate);
-
-        emit RateUpdated(id, newRate, previousRate);
-    }
-
-    function _getRate(Id id, Pair storage info) internal view returns (uint256) {
-        uint256 exchangeRates = IExchangeRateProvider(info.exchangeRateProvider).rate();
-
-        if (exchangeRates == 0) {
-            exchangeRates = IExchangeRateProvider(info.exchangeRateProvider).rate(id);
-        }
-
-        return exchangeRates;
-    }
-
     /**
      * @notice returns the fee percentage for repurchasing(1e18 = 1%)
      * @param id the id of PSM

--- a/contracts/core/assets/Asset.sol
+++ b/contracts/core/assets/Asset.sol
@@ -80,13 +80,13 @@ contract Asset is ERC20Burnable, CustomERC20Permit, Ownable, Expiry, ExchangeRat
 
     string public pairName;
 
-    constructor(
-        string memory _pairName,
-        address _owner,
-        uint256 _expiry,
-        uint256 _rate,
-        uint256 _dsId
-    ) ExchangeRate(_rate) ERC20(_pairName, _pairName) CustomERC20Permit(_pairName) Ownable(_owner) Expiry(_expiry) {
+    constructor(string memory _pairName, address _owner, uint256 _expiry, uint256 _rate, uint256 _dsId)
+        ExchangeRate(_rate)
+        ERC20(_pairName, _pairName)
+        CustomERC20Permit(_pairName)
+        Ownable(_owner)
+        Expiry(_expiry)
+    {
         pairName = _pairName;
         DS_ID = _dsId;
     }

--- a/contracts/core/assets/Asset.sol
+++ b/contracts/core/assets/Asset.sol
@@ -81,19 +81,12 @@ contract Asset is ERC20Burnable, CustomERC20Permit, Ownable, Expiry, ExchangeRat
     string public pairName;
 
     constructor(
-        string memory prefix,
         string memory _pairName,
         address _owner,
         uint256 _expiry,
         uint256 _rate,
         uint256 _dsId
-    )
-        ExchangeRate(_rate)
-        ERC20(string(abi.encodePacked(prefix, "-", _pairName)), string(abi.encodePacked(prefix, "-", _pairName)))
-        CustomERC20Permit(string(abi.encodePacked(prefix, "-", _pairName)))
-        Ownable(_owner)
-        Expiry(_expiry)
-    {
+    ) ExchangeRate(_rate) ERC20(_pairName, _pairName) CustomERC20Permit(_pairName) Ownable(_owner) Expiry(_expiry) {
         pairName = _pairName;
         DS_ID = _dsId;
     }

--- a/contracts/core/assets/AssetFactory.sol
+++ b/contracts/core/assets/AssetFactory.sol
@@ -50,7 +50,7 @@ contract AssetFactory is IAssetFactory, OwnableUpgradeable, UUPSUpgradeable {
 
         // this will assign a fixed variant number to a pair
         // so if the same pair deploys a new asset it will have the same variant number
-        uint256 variantUint = variantIndexPair[id] == 0 ? variantIndex[hash]++ : variantIndexPair[id];
+        uint256 variantUint = variantIndexPair[id] == 0 ? ++variantIndex[hash] : variantIndexPair[id];
         variantIndexPair[id] = variantUint;
 
         variant = string.concat(baseSymbol, "-", Strings.toString(variantUint));

--- a/contracts/core/assets/AssetFactory.sol
+++ b/contracts/core/assets/AssetFactory.sol
@@ -34,6 +34,7 @@ contract AssetFactory is IAssetFactory, OwnableUpgradeable, UUPSUpgradeable {
     mapping(uint256 => Pair) internal pairs;
     mapping(Id => SwapPair[]) internal swapAssets;
     mapping(address => bool) internal deployed;
+    mapping(bytes32 => uint256) internal variantIndex;
 
     /// @notice __gap variable to prevent storage collisions
     // slither-disable-next-line unused-state
@@ -41,6 +42,30 @@ contract AssetFactory is IAssetFactory, OwnableUpgradeable, UUPSUpgradeable {
 
     constructor() {
         _disableInitializers();
+    }
+
+    function _generateVariant(string memory baseSymbol) internal returns(string memory variant){
+        bytes32 hash = keccak256(abi.encodePacked(baseSymbol));
+        uint256 variantUint = ++variantIndex[hash];
+
+        variant =  Strings.toString(variantUint);
+    }
+
+    // will generate symbol such as wstETH03CT-1
+    function _generateSymbolWithVariant(address pa, uint256 expiry, string memory prefix) internal returns(string memory symbol){
+        string memory
+    }
+
+    // will generate symbol such as wstETH03CT or wstETH!LV
+    function _generateSymbol(address pa, uint256 expiry, uint256 prefix) internal  {
+        string memory baseSymbol = IERC20Metadata(pa).symbol();
+        string memory separator = expiry == 0 ? "!" : Strings.toString(BokkyPooBahsDateTimeLibrary.getMonth(expiry));
+        return string.concat(baseSymbol, separator, prefix);
+    }
+
+    function _generateRawSymbols(address pa, uint256 expiry) internal returns(string memory symbol){
+        string memory baseSymbol = IERC20Metadata(pa).symbol();
+        string memory separator = expiry == 0 ? "!" : Strings.toString(BokkyPooBahsDateTimeLibrary.getMonth(expiry));
     }
 
     /**

--- a/contracts/core/assets/AssetFactory.sol
+++ b/contracts/core/assets/AssetFactory.sol
@@ -56,6 +56,8 @@ contract AssetFactory is IAssetFactory, OwnableUpgradeable, UUPSUpgradeable {
         string memory
     }
 
+
+    // TODO : add exchange rate update test
     // will generate symbol such as wstETH03CT or wstETH!LV
     function _generateSymbol(address pa, uint256 expiry, uint256 prefix) internal  {
         string memory baseSymbol = IERC20Metadata(pa).symbol();

--- a/contracts/interfaces/IPSMcore.sol
+++ b/contracts/interfaces/IPSMcore.sol
@@ -275,6 +275,4 @@ interface IPSMcore is IRepurchase {
     function rolloverProfitRemaining(Id id, uint256 dsId) external view returns (uint256);
 
     function psmAutoSellStatus(Id id) external view returns (bool);
-
-    function updateRate(Id id, uint256 newRate) external;
 }

--- a/contracts/interfaces/Init.sol
+++ b/contracts/interfaces/Init.sol
@@ -128,7 +128,15 @@ interface Initialize {
     /// @param ra The address of the redemption asset
     /// @param lv The address of the LV
     /// @param expiry The expiry interval of the DS
-    event InitializedModuleCore(Id indexed id, address indexed pa, address indexed ra, address lv, uint256 expiry);
+    event InitializedModuleCore(
+        Id indexed id,
+        address indexed pa,
+        address indexed ra,
+        address lv,
+        uint256 expiry,
+        uint256 initialArp,
+        address exchangeRateProvider
+    );
 
     /// @notice Emitted when a new DS is issued for a given PSM
     /// @param id The PSM id

--- a/contracts/libraries/DepegSwapLib.sol
+++ b/contracts/libraries/DepegSwapLib.sol
@@ -37,10 +37,6 @@ library DepegSwapLibrary {
         return self._address != address(0) && self.ct != address(0);
     }
 
-    function exchangeRate(DepegSwap storage self) internal view returns (uint256) {
-        return Asset(self._address).exchangeRate();
-    }
-
     function initialize(address _address, address ct) internal pure returns (DepegSwap memory) {
         if (_address == address(0) || ct == address(0)) {
             revert ZeroAddress();

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -74,7 +74,6 @@ library PsmLibrary {
         self.ds[self.globalAssetIdx].updateExchangeRate(rate);
     }
 
-
     function initialize(State storage self, Pair calldata key) external {
         self.info = key;
         self.psm.balances.ra = RedemptionAssetManagerLibrary.initialize(key.redemptionAsset());

--- a/contracts/libraries/PsmLib.sol
+++ b/contracts/libraries/PsmLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Asset, ERC20Burnable} from "../core/assets/Asset.sol";
-import {Pair, PairLibrary} from "./Pair.sol";
+import {Pair, PairLibrary, Id} from "./Pair.sol";
 import {DepegSwap, DepegSwapLibrary} from "./DepegSwapLib.sol";
 import {RedemptionAssetManager, RedemptionAssetManagerLibrary} from "./RedemptionAssetManagerLib.sol";
 import {Signature, MinimalSignatureHelper} from "./SignatureHelperLib.sol";
@@ -16,6 +16,7 @@ import {IDsFlashSwapCore} from "../interfaces/IDsFlashSwapRouter.sol";
 import {VaultLibrary} from "./VaultLib.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {TransferHelper} from "./TransferHelper.sol";
+import {IExchangeRateProvider} from "./../interfaces/IExchangeRateProvider.sol";
 
 /**
  * @title Psm Library Contract
@@ -47,6 +48,33 @@ library PsmLibrary {
         status = self.info.isInitialized();
     }
 
+    function _getLatestRate(State storage self) internal view returns (uint256 rate) {
+        Id id = self.info.toId();
+
+        uint256 exchangeRates = IExchangeRateProvider(self.info.exchangeRateProvider).rate();
+
+        if (exchangeRates == 0) {
+            exchangeRates = IExchangeRateProvider(self.info.exchangeRateProvider).rate(id);
+        }
+
+        return exchangeRates;
+    }
+
+    function _getLatestApplicableRate(State storage self) internal view returns (uint256 rate) {
+        uint256 externalExchangeRates = _getLatestRate(self);
+        uint256 currentExchangeRates = Asset(self.ds[self.globalAssetIdx]._address).exchangeRate();
+
+        // return the lower of the two
+        return externalExchangeRates < currentExchangeRates ? externalExchangeRates : currentExchangeRates;
+    }
+
+    // fetch and update the exchange rate. will return the lowest rate
+    function _getLatestApplicableRateAndUpdate(State storage self) internal returns (uint256 rate) {
+        rate = _getLatestApplicableRate(self);
+        self.ds[self.globalAssetIdx].updateExchangeRate(rate);
+    }
+
+
     function initialize(State storage self, Pair calldata key) external {
         self.info = key;
         self.psm.balances.ra = RedemptionAssetManagerLibrary.initialize(key.redemptionAsset());
@@ -54,32 +82,6 @@ library PsmLibrary {
 
     function updateAutoSell(State storage self, address user, bool status) external {
         self.psm.autoSell[user] = status;
-    }
-
-    function updateExchangeRate(State storage self, uint256 newRate) external {
-        if (newRate == 0) {
-            revert IErrors.InvalidRate();
-        }
-        uint256 currentRate = self.ds[self.globalAssetIdx].exchangeRate();
-
-        _ensureRateIsInDeltaRange(currentRate, newRate);
-
-        self.ds[self.globalAssetIdx].updateExchangeRate(newRate);
-    }
-
-    function _ensureRateIsInDeltaRange(uint256 currentRate, uint256 newRate) internal {
-        // rate must never go higher than the current rate
-        if (newRate > currentRate) {
-            revert IErrors.InvalidRate();
-        }
-
-        uint256 delta = MathHelper.calculatePercentageFee(DepegSwapLibrary.MAX_RATE_DELTA_PERCENTAGE, currentRate);
-        delta = currentRate - delta;
-
-        // rate must never go down below delta
-        if (newRate < delta) {
-            revert IErrors.InvalidRate();
-        }
     }
 
     function autoSellStatus(State storage self, address user) external view returns (bool status) {
@@ -341,7 +343,7 @@ library PsmLibrary {
         DepegSwap storage ds = self.ds[dsId];
 
         Guard.safeBeforeExpired(ds);
-        _exchangeRate = ds.exchangeRate();
+        _exchangeRate = _getLatestApplicableRateAndUpdate(self);
 
         // we convert it 18 fixed decimals, since that's what the DS uses
         received = TransferHelper.tokenNativeDecimalsToFixed(amount, self.info.ra);
@@ -441,7 +443,7 @@ library PsmLibrary {
         DepegSwap storage ds = self.ds[dsId];
         Guard.safeBeforeExpired(ds);
 
-        rates = ds.exchangeRate();
+        rates = _getLatestApplicableRate(self);
     }
 
     function repurchaseFeePercentage(State storage self) external view returns (uint256 rates) {
@@ -485,7 +487,7 @@ library PsmLibrary {
         ds = self.ds[dsId];
         Guard.safeBeforeExpired(ds);
 
-        exchangeRates = ds.exchangeRate();
+        exchangeRates = _getLatestApplicableRate(self);
 
         // the fee is taken directly from RA before it's even converted to DS
         {
@@ -622,7 +624,7 @@ library PsmLibrary {
     function exchangeRate(State storage self) external view returns (uint256 rates) {
         uint256 dsId = self.globalAssetIdx;
         DepegSwap storage ds = self.ds[dsId];
-        rates = ds.exchangeRate();
+        rates = _getLatestApplicableRate(self);
     }
 
     /// @notice redeem an RA with DS + PA
@@ -664,7 +666,7 @@ library PsmLibrary {
         DepegSwap storage _ds = self.ds[dsId];
         Guard.safeBeforeExpired(_ds);
 
-        exchangeRates = _ds.exchangeRate();
+        exchangeRates = _getLatestApplicableRate(self);
         // the amount here is the PA amount
         amount = TransferHelper.tokenNativeDecimalsToFixed(amount, self.info.pa);
         uint256 raDs = MathHelper.calculateEqualSwapAmount(amount, exchangeRates);

--- a/test/forge/integration/config/RateUpdate.t.sol
+++ b/test/forge/integration/config/RateUpdate.t.sol
@@ -1,0 +1,67 @@
+pragma solidity ^0.8.24;
+
+import "./../../Helper.sol";
+import "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import "./../../../../contracts/core/assets/Asset.sol";
+
+contract RateUpdateTest is Helper {
+    function setUp() external {
+        vm.startPrank(DEFAULT_ADDRESS);
+        deployModuleCore();
+        initializeAndIssueNewDs(100);
+    }
+
+    function test_shouldUpdateRateDownCorrectly() external {
+        uint256 rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1 ether);
+
+        corkConfig.updatePsmRate(defaultCurrencyId, 0.9 ether);
+
+        rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 0.9 ether);
+    }
+
+    function test_shouldUpdateRateUpCorrectlyOnNewIssuance() external {
+        uint256 rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1 ether);
+
+        initializeAndIssueNewDs(1000);
+
+        corkConfig.updatePsmRate(defaultCurrencyId, 1.1 ether);
+
+        rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1 ether);
+
+        ff_expired();
+
+        rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1.1 ether);
+    }
+
+    // ff to expiry and update infos
+    function ff_expired() internal {
+        (,address ds) = moduleCore.swapAsset(defaultCurrencyId, 1);
+
+        // fast forward to expiry
+        uint256 expiry = Asset(ds).expiry();
+        vm.warp(expiry);
+        issueNewDs(defaultCurrencyId);
+    }
+
+    function test_ShouldNotUpdateRateUpCorrectlyOnActive() external {
+        uint256 rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1 ether);
+
+        corkConfig.updatePsmRate(defaultCurrencyId, 1.1 ether);
+
+        rate = moduleCore.exchangeRate(defaultCurrencyId);
+
+        vm.assertEq(rate, 1 ether);
+    }
+}

--- a/test/forge/integration/config/RateUpdate.t.sol
+++ b/test/forge/integration/config/RateUpdate.t.sol
@@ -45,7 +45,7 @@ contract RateUpdateTest is Helper {
 
     // ff to expiry and update infos
     function ff_expired() internal {
-        (,address ds) = moduleCore.swapAsset(defaultCurrencyId, 1);
+        (, address ds) = moduleCore.swapAsset(defaultCurrencyId, 1);
 
         // fast forward to expiry
         uint256 expiry = Asset(ds).expiry();

--- a/test/forge/unit/tokenNames/TokenNames.t.sol
+++ b/test/forge/unit/tokenNames/TokenNames.t.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.8.24;
+
+import "./../../Helper.sol";
+import "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+
+contract TokenName is Helper {
+    function setUp() external {
+        vm.startPrank(DEFAULT_ADDRESS);
+        // saturday, June 3, 2000 1:07:47 PM
+        // 06/03/2000 @ 1:07:47pm
+        vm.warp(960037567);
+        deployModuleCore();
+        initializeAndIssueNewDs(100);
+    }
+
+    function test_tokenNames() external {
+        (address ct, address ds) = moduleCore.swapAsset(defaultCurrencyId, 1);
+        address lv = moduleCore.lvAsset(defaultCurrencyId);
+
+        IERC20Metadata ctToken = IERC20Metadata(ct);
+        IERC20Metadata dsToken = IERC20Metadata(ds);
+        IERC20Metadata lvToken = IERC20Metadata(lv);
+
+        vm.assertEq(ctToken.symbol(), "DWETH6CT-1");
+        vm.assertEq(dsToken.symbol(), "DWETH6DS-1");
+        vm.assertEq(lvToken.symbol(), "DWETH!LV-1");
+
+        initializeAndIssueNewDs(1000);
+
+        (ct, ds) = moduleCore.swapAsset(defaultCurrencyId, 1);
+        lv = moduleCore.lvAsset(defaultCurrencyId);
+
+        ctToken = IERC20Metadata(ct);
+        dsToken = IERC20Metadata(ds);
+        lvToken = IERC20Metadata(lv);
+
+        vm.assertEq(ctToken.symbol(), "DWETH6CT-2");
+        vm.assertEq(dsToken.symbol(), "DWETH6DS-2");
+        vm.assertEq(lvToken.symbol(), "DWETH!LV-2");
+    }
+}


### PR DESCRIPTION
# Changes

List of Changes:
 - properly fetch rate from the oracle
 - remove bug that allows the protocol to bypass checks and change other markets exchange rate that doesn't use our oracle
 - token symbol convention renaming
 - only enforce higher exchange rate at new issuance
 - only allow the exchange rate to go down during active issuance



# Warning
- this removed the check that prevent the rate updating on at max 10% lower since this might cause issues with 3rd party oracle that wish to integrate with us. If market creators still want this behavior they should built the logic directly to the oracle

