### PR TITLE
Fix/deposit inflation

### DIFF
--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -69,19 +69,19 @@ abstract contract ModuleState is IErrors, ReentrancyGuardTransient {
         WITHDRAWAL_CONTRACT = _withdrawalContract;
     }
 
-    function getRouterCore() internal view returns (RouterState) {
+    function getRouterCore() public view returns (RouterState) {
         return RouterState(DS_FLASHSWAP_ROUTER);
     }
 
-    function getAmmRouter() internal view returns (ICorkHook) {
+    function getAmmRouter() public view returns (ICorkHook) {
         return ICorkHook(AMM_HOOK);
     }
 
-    function getWithdrawalContract() internal view returns (Withdrawal) {
+    function getWithdrawalContract() public view returns (Withdrawal) {
         return Withdrawal(WITHDRAWAL_CONTRACT);
     }
 
-    function getTreasuryAddress() internal view returns (address) {
+    function getTreasuryAddress() public view returns (address) {
         return CorkConfig(CONFIG).treasury();
     }
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -27,6 +27,7 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
     function depositLv(Id id, uint256 amount, uint256 raTolerance, uint256 ctTolerance)
         external
         override
+        nonReentrant
         returns (uint256 received)
     {
         LVDepositNotPaused(id);

--- a/contracts/libraries/MathHelper.sol
+++ b/contracts/libraries/MathHelper.sol
@@ -258,10 +258,10 @@ library MathHelper {
         navCt = calculateNav(prices.ctPrice, ud(params.vaultCt));
         navDs = calculateNav(prices.dsPrice, ud(params.vaultDs));
 
-        UD60x18 raPerLp = div(ud(params.lpSupply), ud(params.reserveRa));
+        UD60x18 raPerLp = div(ud(params.reserveRa), ud(params.lpSupply));
         UD60x18 navRaLp = calculateNav(prices.raPrice, mul(ud(params.vaultLp), raPerLp));
 
-        UD60x18 ctPerLp = div(ud(params.lpSupply), ud(params.reserveCt));
+        UD60x18 ctPerLp = div(ud(params.reserveCt), ud(params.lpSupply));
         UD60x18 navCtLp = calculateNav(prices.ctPrice, mul(ud(params.vaultLp), ctPerLp));
 
         navIdleRa = calculateNav(prices.raPrice, ud(params.vaultIdleRa));

--- a/contracts/libraries/State.sol
+++ b/contracts/libraries/State.sol
@@ -68,6 +68,7 @@ struct Balances {
 struct VaultBalances {
     RedemptionAssetManager ra;
     uint256 ctBalance;
+    uint256 lpBalance;
 }
 
 /**

--- a/contracts/libraries/VaultBalancesLib.sol
+++ b/contracts/libraries/VaultBalancesLib.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.24;
+
+library VaultBalanceLibrary {
+    function syncLpToken() internal {}
+}

--- a/contracts/libraries/VaultBalancesLib.sol
+++ b/contracts/libraries/VaultBalancesLib.sol
@@ -1,6 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 
+import {ICorkHook} from "./../interfaces/UniV4/IMinimalHook.sol";
+import {State} from "./State.sol";
+import {DepegSwap} from "./DepegSwapLib.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
 library VaultBalanceLibrary {
-    function syncLpToken() internal {}
+    function syncLpBalance(State storage self, ICorkHook ammRouter, uint256 dsId) internal {
+        DepegSwap storage ds = self.ds[dsId];
+        syncLpBalance(self, ammRouter, ds.ct);
+    }
+
+    function syncLpBalance(State storage self, ICorkHook ammRouter, address ct) internal {
+        // the only case where this fails is when the AMM is not yet initialized,
+        // an edge case where this would happen is when a user would deposit a very small amount
+        // of RA at initialization(e.g 1), before the AMM is initialized.
+        // in that case it's safe to reset the lp balance back to 0
+        try ammRouter.getLiquidityToken(self.info.ra, ct) returns (address _lpToken) {
+            IERC20 lpToken = IERC20(_lpToken);
+            self.vault.balances.lpBalance = lpToken.balanceOf(address(this));
+        } catch {
+            self.vault.balances.lpBalance = 0;
+        }
+    }
+
+    function lpBalance(State storage self) internal view returns (uint256) {
+        return self.vault.balances.lpBalance;
+    }
 }

--- a/contracts/libraries/VaultBalancesLib.sol
+++ b/contracts/libraries/VaultBalancesLib.sol
@@ -7,22 +7,12 @@ import {DepegSwap} from "./DepegSwapLib.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 library VaultBalanceLibrary {
-    function syncLpBalance(State storage self, ICorkHook ammRouter, uint256 dsId) internal {
-        DepegSwap storage ds = self.ds[dsId];
-        syncLpBalance(self, ammRouter, ds.ct);
+    function subtractLpBalance(State storage self, uint256 amount) internal {
+        self.vault.balances.lpBalance -= amount;
     }
 
-    function syncLpBalance(State storage self, ICorkHook ammRouter, address ct) internal {
-        // the only case where this fails is when the AMM is not yet initialized,
-        // an edge case where this would happen is when a user would deposit a very small amount
-        // of RA at initialization(e.g 1), before the AMM is initialized.
-        // in that case it's safe to reset the lp balance back to 0
-        try ammRouter.getLiquidityToken(self.info.ra, ct) returns (address _lpToken) {
-            IERC20 lpToken = IERC20(_lpToken);
-            self.vault.balances.lpBalance = lpToken.balanceOf(address(this));
-        } catch {
-            self.vault.balances.lpBalance = 0;
-        }
+    function addLpBalance(State storage self, uint256 amount) internal {
+        self.vault.balances.lpBalance += amount;
     }
 
     function lpBalance(State storage self) internal view returns (uint256) {

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -418,7 +418,7 @@ library VaultLibrary {
             oneMinusT: snapshot.oneMinusT,
             lpSupply: lpSupply,
             lvSupply: Asset(self.vault.lv._address).totalSupply(),
-            // the provide liquidity automatically adds the lp, so we need to subtract it first here
+            // we already split the CT so we need to subtract it first here
             vaultCt: self.vault.balances.ctBalance - params.ctSplitted,
             vaultDs: params.flashSwapRouter.getLvReserve(id, params.dsId),
             vaultLp: vaultLp,

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -22,6 +22,7 @@ import {LiquidityToken} from "Cork-Hook/LiquidityToken.sol";
 import {MarketSnapshot} from "Cork-Hook/lib/MarketSnapshot.sol";
 import {IWithdrawalRouter} from "./../interfaces/IWithdrawalRouter.sol";
 import {TransferHelper} from "./TransferHelper.sol";
+import {VaultBalanceLibrary} from "./VaultBalancesLib.sol";
 
 /**
  * @title Vault Library Contract
@@ -38,6 +39,7 @@ library VaultLibrary {
     using DepegSwapLibrary for DepegSwap;
     using VaultPoolLibrary for VaultPool;
     using SafeERC20 for IERC20;
+    using VaultBalanceLibrary for State;
 
     // for avoiding stack too deep errors
     struct Tolerance {

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -403,7 +403,7 @@ library VaultLibrary {
             lvSupply: Asset(self.vault.lv._address).totalSupply(),
             // we already split the CT so we need to subtract it first here
             vaultCt: self.vault.balances.ctBalance - params.ctSplitted,
-            vaultDs: params.flashSwapRouter.getLvReserve(id, params.dsId),
+            vaultDs: params.flashSwapRouter.getLvReserve(id, params.dsId) - params.ctSplitted,
             vaultLp: vaultLp,
             vaultIdleRa: TransferHelper.tokenNativeDecimalsToFixed(self.vault.balances.ra.locked, self.info.ra)
         });

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -372,6 +372,8 @@ library VaultLibrary {
         }
 
         self.vault.lv.issue(from, received);
+
+        self.syncLpBalance(ammRouter, dsId);
     }
 
     function _calculateReceivedDeposit(

--- a/test/forge/integration/vault/deposit/Deposit.t.sol
+++ b/test/forge/integration/vault/deposit/Deposit.t.sol
@@ -579,7 +579,7 @@ contract DepositTest is Helper {
         // ~0.5 from split, ~0.2 from AMM with some precision tolerance
         vm.assertApproxEqAbs(dsReserve, depositAmount * 3 / 4, depositAmount / 100);
 
-        vm.assertEq(received, 1);
+        vm.assertEq(received, 2);
 
         (received,) = moduleCore.depositPsm(defaultCurrencyId, 1 ether);
 

--- a/test/forge/integration/vault/deposit/Deposit.t.sol
+++ b/test/forge/integration/vault/deposit/Deposit.t.sol
@@ -305,4 +305,41 @@ contract DepositTest is Helper {
         vm.expectRevert();
         received = moduleCore.depositLv(id, amount, 100000 ether, 10000 ether);
     }
+
+    function test_depositInflation() external {
+        uint256 depositAmount = 2;
+
+        uint256 adjustedDepositAmount = depositAmount;
+
+        VaultBalances memory balances = moduleCore.getVaultBalances(defaultCurrencyId);
+        vm.assertEq(balances.ra.locked, 0);
+        vm.assertEq(balances.ctBalance, 0);
+
+        uint256 received = moduleCore.depositLv(defaultCurrencyId, adjustedDepositAmount, 0, 0);
+
+        balances = moduleCore.getVaultBalances(defaultCurrencyId);
+        vm.assertEq(balances.ra.locked, 0);
+
+        // default split is 50/50
+        vm.assertApproxEqAbs(balances.ctBalance, depositAmount / 2, depositAmount / 100);
+
+        uint256 dsReserve = flashSwapRouter.getLvReserve(defaultCurrencyId, 1);
+        // ~0.5 from split, ~0.2 from AMM with some precision tolerance
+        vm.assertApproxEqAbs(dsReserve, depositAmount * 3 / 4, depositAmount / 100);
+
+        vm.assertEq(received, 1);
+
+        (received,) = moduleCore.depositPsm(defaultCurrencyId, 1 ether);
+
+        ICorkHook ammRouter = moduleCore.getAmmRouter();
+        ra.approve(address(ammRouter), 1 ether);
+        IERC20(ct).approve(address(ammRouter), 1 ether);
+        (,, uint256 minted) = ammRouter.addLiquidity(address(ra), ct, 1 ether, 1 ether, 0, 0, block.timestamp);
+
+        vm.assertGe(minted, 1e9);
+        IERC20(ammRouter.getLiquidityToken(address(ra), ct)).transfer(address(moduleCore), minted);
+
+        received = moduleCore.depositLv(defaultCurrencyId, 1 ether, 0, 0);
+        vm.assertGe(received, 100);
+    }
 }

--- a/test/forge/unit/vaultMath/navMath.sol
+++ b/test/forge/unit/vaultMath/navMath.sol
@@ -64,7 +64,7 @@ contract NavMathTest is Test {
         });
 
         (UD60x18 navLp, UD60x18 navCt, UD60x18 navDs, UD60x18 navIdleRa) = MathHelper.calculateNavCombined(params);
-        vm.assertApproxEqAbs(unwrap(navLp), 2004.31706 ether, 0.00001 ether);
+        vm.assertApproxEqAbs(unwrap(navLp), 2004.8909 ether, 0.0001 ether);
         vm.assertApproxEqAbs(unwrap(navCt), 957.03 ether, 0.01 ether);
         vm.assertApproxEqAbs(unwrap(navDs), 88.07 ether, 0.01 ether);
         vm.assertApproxEqAbs(unwrap(navIdleRa), 15 ether, 0.0001 ether);


### PR DESCRIPTION
# Changes

List of Changes:
 - Auto sync LP token balance after removing liquidity.
 - Auto sync LP token balance after providing liquidity only on new issuance.
 - Sync LP token balance separately after adding liquidity on deposit. We have to do this way since the amount of LP we get is needed to calculate user shares.
 - minor fix in nav math with swapped variable relating to calculating NAV assets
 - actually provision liquidty after calculating the LV amount user get