### PR TITLE
Correctly calculate tolerance on deposit

### DIFF
--- a/contracts/core/assets/ProtectedUnit.sol
+++ b/contracts/core/assets/ProtectedUnit.sol
@@ -339,12 +339,8 @@ contract ProtectedUnit is
         bytes calldata rawPaPermitSig,
         uint256 deadline
     ) external whenNotPaused nonReentrant autoUpdateDS autoSync returns (uint256 dsAmount, uint256 paAmount) {
-        if (rawDsPermitSig.length == 0 || rawPaPermitSig.length == 0 || deadline == 0) {
+        if (rawDsPermitSig.length == 0  || deadline == 0) {
             revert InvalidSignature();
-        }
-
-        if (!PermitChecker.supportsPermit(address(PA))) {
-            revert PermitNotSupported();
         }
 
         (dsAmount, paAmount) = previewMint(amount);

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -173,10 +173,14 @@ library VaultLibrary {
         uint256 amount,
         IDsFlashSwapCore flashSwapRouter,
         address ctAddress,
-        ICorkHook ammRouter,
-        Tolerance memory tolerance
+        ICorkHook ammRouter
     ) internal returns (uint256 ra, uint256 ct, uint256 dust) {
+        Tolerance memory tolerance;
+
         (ra, ct) = __calculateProvideLiquidityAmount(self, amount, flashSwapRouter);
+
+        (tolerance.ra, tolerance.ct) = MathHelper.calculateWithTolerance(ra, ct, MathHelper.UNI_STATIC_TOLERANCE);
+
         (, dust) = __provideLiquidity(self, ra, ct, flashSwapRouter, ctAddress, ammRouter, tolerance, amount);
     }
 
@@ -198,12 +202,7 @@ library VaultLibrary {
         address ctAddress,
         ICorkHook ammRouter
     ) internal returns (uint256 ra, uint256 ct, uint256 dust) {
-        (uint256 raTolerance, uint256 ctTolerance) =
-            MathHelper.calculateWithTolerance(ra, ct, MathHelper.UNI_STATIC_TOLERANCE);
-
-        (ra, ct, dust) = __provideLiquidityWithRatioGetDust(
-            self, amount, flashSwapRouter, ctAddress, ammRouter, Tolerance(raTolerance, ctTolerance)
-        );
+        (ra, ct, dust) = __provideLiquidityWithRatioGetDust(self, amount, flashSwapRouter, ctAddress, ammRouter);
     }
 
     function __getAmmCtPriceRatio(State storage self, IDsFlashSwapCore flashSwapRouter, uint256 dsId)


### PR DESCRIPTION
# Changes

List of Changes:
 - BREAKING : change separate RA:CT tolerance to percentage based tolerance on LV deposits
 - remove PA checks in protected unit

