### PR TITLE
Fix/adjust pressure cap

### DIFF
--- a/contracts/libraries/DsSwapperMathLib.sol
+++ b/contracts/libraries/DsSwapperMathLib.sol
@@ -133,7 +133,7 @@ library SwapperMathLibrary {
     int256 internal constant ONE_MINUS_T_CAP = 1e18;
 
     // ds reserve sell pressure cap, set to 95% to still allow price impact being made
-    uint256 internal constant SELL_PRESSURE_CAP = 95e18;
+    uint256 internal constant SELL_PRESSURE_CAP = 97.5 ether; // same as 97.5 x 1e18
 
     // Calculate price ratio of two tokens in AMM, will return ratio on 18 decimals precision
     function getPriceRatio(uint256 raReserve, uint256 ctReserve)

--- a/test/forge/integration/router/buy/Buy.t.sol
+++ b/test/forge/integration/router/buy/Buy.t.sol
@@ -187,8 +187,7 @@ contract BuyDsTest is Helper {
             currencyId, dsId, amount, 0, defaultBuyApproxParams(), defaultOffchainGuessParams()
         );
 
-        // won't be exact
-        vm.assertEq(result.reserveSellPressure, 95 ether);
+        vm.assertEq(result.reserveSellPressure, 97.5 ether);
     }
 
     function testFuzz_buyDS(uint256 amount, uint8 raDecimals, uint8 paDecimals) public {


### PR DESCRIPTION
# Changes

List of Changes:
 - change the soft max for the cap to be 97.5%
 

# Notes
The 2 tests that are failing is because of #350 and should be resolved if #350  pass the spearbit audit