### PR TITLE
Fix/pause liquidation

### DIFF
--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -23,7 +23,8 @@ import {AmmId, toAmmId} from "Cork-Hook/lib/State.sol";
 contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize, VaultCore {
     /// @notice __gap variable to prevent storage collisions
     // slither-disable-next-line unused-state
-    uint256[49] private __gap;
+    // upgrade to add access control for pausing PA liquidation
+    uint256[48] private __gap;
 
     using PsmLibrary for State;
     using PairLibrary for Pair;

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -34,6 +34,9 @@ abstract contract ModuleState is IErrors, ReentrancyGuardTransient {
 
     address internal WITHDRAWAL_CONTRACT;
 
+    /// @dev new storage variable
+    mapping(Id => address) public activeLiquidator;
+
     /**
      * @dev checks if caller is config contract or not
      */

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -149,7 +149,7 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
         onlyWhiteListedLiquidationContract();
         /// @dev we set the executor address here.
         /// this will be used to know who is the active liquidator that handle a pool PA liquidation
-        /// only this address will be allowed to call receiveTradeExecuctionResultFunds and useTradeExecutionResultFunds
+        /// only this address will be allowed to call receiveTradeExecuctionResultFunds and receiveLeftoverFunds
         /// this is restricted because now we will pause the vault withdrawal. If we allow anyone to call it then it'll have a DoS surface of attack
         activeLiquidator[id] = executor;
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -57,7 +57,7 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
             withdrawalContract: getWithdrawalContract()
         });
 
-        result = states[redeemParams.id].redeemEarly(msg.sender, redeemParams, routers, permitParams);
+        result = states[redeemParams.id].redeemEarly(_msgSender(), redeemParams, routers, permitParams);
 
         emit LvRedeemEarly(
             redeemParams.id,
@@ -119,7 +119,7 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
         onlyFlashSwapRouter();
         State storage state = states[id];
         state.allocateFeesToVault(amount);
-        emit VaultDsSaleProfitReceived(msg.sender, id, amount);
+        emit VaultDsSaleProfitReceived(_msgSender(), id, amount);
     }
 
     /**
@@ -141,24 +141,35 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
         states[id].updateCtHeldPercentage(ctHeldPercentage);
     }
 
-    function requestLiquidationFunds(Id id, uint256 amount) external override {
+    function requestLiquidationFunds(Id id, uint256 amount, address executor) external override {
         onlyWhiteListedLiquidationContract();
+        /// @dev we set the executor address here.
+        /// this will be used to know who is the active liquidator that handle a pool PA liquidation
+        /// only this address will be allowed to call receiveTradeExecuctionResultFunds and useTradeExecutionResultFunds
+        /// this is restricted because now we will pause the vault withdrawal. If we allow anyone to call it then it'll have a DoS surface of attack
+        activeLiquidator[id] = executor;
+
         State storage state = states[id];
-        state.requestLiquidationFunds(amount, msg.sender);
-        emit LiquidationFundsRequested(id, msg.sender, amount);
+        state.requestLiquidationFunds(amount, _msgSender());
+        emit LiquidationFundsRequested(id, _msgSender(), amount);
     }
 
     function receiveTradeExecuctionResultFunds(Id id, uint256 amount) external override {
         State storage state = states[id];
-        state.receiveTradeExecuctionResultFunds(amount, msg.sender);
-        emit TradeExecutionResultFundsReceived(id, msg.sender, amount);
+
+        if (_msgSender() != activeLiquidator[id]) {
+            revert OnlyWhiteListed();
+        }
+
+        state.receiveTradeExecuctionResultFunds(amount, _msgSender());
+        emit TradeExecutionResultFundsReceived(id, _msgSender(), amount);
     }
 
     function useTradeExecutionResultFunds(Id id) external override {
         onlyConfig();
         State storage state = states[id];
         uint256 used = state.useTradeExecutionResultFunds(getRouterCore(), getAmmRouter());
-        emit TradeExecutionResultFundsUsed(id, msg.sender, used);
+        emit TradeExecutionResultFundsUsed(id, _msgSender(), used);
     }
 
     function liquidationFundsAvailable(Id id) external view returns (uint256) {
@@ -178,6 +189,14 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
     }
 
     function receiveLeftoverFunds(Id id, uint256 amount) external override {
+        if (_msgSender() != activeLiquidator[id]) {
+            revert OnlyWhiteListed();
+        }
+
+        /// @dev we reset liquidator address
+        /// the reason we do this here is that the liquidator contract will and must call this function last when finishing order in the liquidator contract
+        delete activeLiquidator[id];
+
         states[id].receiveLeftoverFunds(amount, _msgSender());
     }
 

--- a/contracts/core/Vault.sol
+++ b/contracts/core/Vault.sol
@@ -159,12 +159,11 @@ abstract contract VaultCore is ModuleState, Context, IVault, IVaultLiquidation {
     }
 
     function receiveTradeExecuctionResultFunds(Id id, uint256 amount) external override {
-        State storage state = states[id];
-
         if (_msgSender() != activeLiquidator[id]) {
             revert OnlyWhiteListed();
         }
 
+        State storage state = states[id];
         state.receiveTradeExecuctionResultFunds(amount, _msgSender());
         emit TradeExecutionResultFundsReceived(id, _msgSender(), amount);
     }

--- a/contracts/core/liquidators/cow-protocol/Liquidator.sol
+++ b/contracts/core/liquidators/cow-protocol/Liquidator.sol
@@ -172,7 +172,7 @@ contract Liquidator is ILiquidator {
     }
 
     function _moveVaultFunds(Details memory details, Id id, address liquidator) internal {
-        IVaultLiquidation(MODULE_CORE).requestLiquidationFunds(id, details.sellAmount);
+        IVaultLiquidation(MODULE_CORE).requestLiquidationFunds(id, details.sellAmount, liquidator);
 
         SafeERC20.safeTransfer(IERC20(details.sellToken), liquidator, details.sellAmount);
     }

--- a/contracts/interfaces/IVaultLiquidation.sol
+++ b/contracts/interfaces/IVaultLiquidation.sol
@@ -10,9 +10,10 @@ interface IVaultLiquidation {
     /// @notice Request funds for liquidation, will transfer the funds directly from the vault to the liquidation contract
     /// @param id The id of the vault
     /// @param amount The amount of funds to request
+    /// @param executor The actual trade executor, this is the contract that holds all the funds associated with the trade
     /// will revert if there's not enough funds in the vault
     /// IMPORTANT :  the vault must make sure only whitelisted liquidation contract adddress can call this function
-    function requestLiquidationFunds(Id id, uint256 amount) external;
+    function requestLiquidationFunds(Id id, uint256 amount, address executor) external;
 
     /// @notice Receive funds from liquidation, the vault will do a transferFrom from the liquidation contract
     /// it is important to note that the vault will only transfer RA from the liquidation contract

--- a/contracts/libraries/VaultLib.sol
+++ b/contracts/libraries/VaultLib.sol
@@ -753,6 +753,10 @@ library VaultLibrary {
             revert IErrors.InsufficientFunds();
         }
 
+        /// @dev we pause withdrawal when the liquidation is happening
+        /// since if user withdraw when liquidation is happening, they won't receive their fair PA share since some of it now sits in the liquidator contract
+        self.vault.config.isWithdrawalPaused = true;
+
         self.vault.pool.withdrawalPool.paBalance -= amount;
         SafeERC20.safeTransfer(IERC20(self.info.pa), to, amount);
     }
@@ -784,6 +788,10 @@ library VaultLibrary {
         // transfer PA to the vault
         SafeERC20.safeTransferFrom(IERC20(self.info.pa), from, address(this), amount);
         self.vault.pool.withdrawalPool.paBalance += amount;
+
+        /// @dev we resume withdrawal
+        /// the reason we do this here is that the liquidator contract will and must call this function last when finishing order in the liquidator contract
+        self.vault.config.isWithdrawalPaused = false;
     }
 
     function updateLvDepositsStatus(State storage self, bool isLVDepositPaused) external {

--- a/test/forge/integration/vault/LiquidityFunds.t.sol
+++ b/test/forge/integration/vault/LiquidityFunds.t.sol
@@ -53,6 +53,10 @@ contract VaultLiquidityFundsTest is Helper {
         (ct, ds) = moduleCore.swapAsset(currencyId, dsId);
     }
 
+    function caller() internal returns (address caller) {
+        (, caller,) = vm.readCallers();
+    }
+
     // ff to expiry and update infos
     function ff_expired() internal {
         // fast forward to expiry
@@ -73,7 +77,7 @@ contract VaultLiquidityFundsTest is Helper {
         vm.assertEq(fundsAvailable, 0);
 
         vm.expectRevert(IErrors.InsufficientFunds.selector);
-        moduleCore.requestLiquidationFunds(currencyId, 1 ether);
+        moduleCore.requestLiquidationFunds(currencyId, 1 ether, caller());
     }
 
     function test_requestAfterExpiries() external {
@@ -87,7 +91,7 @@ contract VaultLiquidityFundsTest is Helper {
 
         vm.assertTrue(fundsAvailable > 0);
 
-        moduleCore.requestLiquidationFunds(currencyId, fundsAvailable);
+        moduleCore.requestLiquidationFunds(currencyId, fundsAvailable, caller());
 
         fundsAvailable = moduleCore.liquidationFundsAvailable(currencyId);
         vm.assertEq(fundsAvailable, 0);
@@ -97,13 +101,25 @@ contract VaultLiquidityFundsTest is Helper {
         vm.stopPrank();
 
         vm.expectRevert(IErrors.OnlyWhiteListed.selector);
-        moduleCore.requestLiquidationFunds(currencyId, 1 ether);
+        moduleCore.requestLiquidationFunds(currencyId, 1 ether, caller());
     }
 
     function test_receiveFunds() external {
+        uint256 amount = 1000 ether;
+        // we redeem 1000 RA first first
+        Asset(ds).approve(address(moduleCore), 1000 ether);
+        moduleCore.redeemRaWithDsPa(currencyId, dsId, 1000 ether);
+
+        ff_expired();
+
+        uint256 fundsAvailable = moduleCore.liquidationFundsAvailable(currencyId);
+
+        vm.assertTrue(fundsAvailable > 0);
+
+        moduleCore.requestLiquidationFunds(currencyId, fundsAvailable, caller());
+
         uint256 raBalanceBefore = ra.balanceOf(address(moduleCore));
 
-        uint256 amount = 1000 ether;
         ra.approve(address(moduleCore), amount);
 
         moduleCore.receiveTradeExecuctionResultFunds(currencyId, amount);
@@ -115,13 +131,26 @@ contract VaultLiquidityFundsTest is Helper {
 
     function test_useFundsAfterReceive() external {
         uint256 amount = 1000 ether;
+
+        // we redeem 1000 RA first first
+        Asset(ds).approve(address(moduleCore), 1000 ether);
+        moduleCore.redeemRaWithDsPa(currencyId, dsId, 1000 ether);
+
+        ff_expired();
+
+        uint256 fundsAvailable = moduleCore.liquidationFundsAvailable(currencyId);
+
+        vm.assertTrue(fundsAvailable > 0);
+
+        moduleCore.requestLiquidationFunds(currencyId, fundsAvailable, caller());
+
         ra.approve(address(moduleCore), amount);
 
         moduleCore.receiveTradeExecuctionResultFunds(currencyId, amount);
 
         uint256 tradeFundsAvailable = moduleCore.tradeExecutionFundsAvailable(currencyId);
 
-        vm.assertEq(tradeFundsAvailable, 1000 ether);
+        vm.assertEq(tradeFundsAvailable, 1010 ether);
 
         corkConfig.useVaultTradeExecutionResultFunds(currencyId);
 


### PR DESCRIPTION
# Changes

List of Changes:
 - Pause vault withdrawal when a liquidation is happening
 - Resume vault withdrawal when the active liquidator sends all the remaining leftover PA back to vault
 - Restrict access to liquidation related functions


# Notes
The failing test will be resolved when #349 is merged 

