### PR TITLE
Fix: Protected Unit conversion and misassignment

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -16,7 +16,7 @@ on:
       - "test/**"
     branches:
       - main
-      - tmp-changes
+      - audit/spearbit-fixes
 
 jobs:
   forge-test:

--- a/contracts/core/assets/ProtectedUnit.sol
+++ b/contracts/core/assets/ProtectedUnit.sol
@@ -94,7 +94,7 @@ contract ProtectedUnit is
     DSData[] public dsHistory;
 
     /// @notice Mapping from DS token address to its index in dsHistory array
-    mapping(address => uint256) private dsIndexMap;
+    mapping(address => uint256) public dsIndexMap;
 
     /// @notice __gap variable to prevent storage collisions
     // slither-disable-next-line unused-state

--- a/contracts/core/assets/ProtectedUnit.sol
+++ b/contracts/core/assets/ProtectedUnit.sol
@@ -485,10 +485,6 @@ contract ProtectedUnit is
      * @dev Handles the token transfers and minting logic
      */
     function __mint(uint256 amount, uint256 dsAmount, uint256 paAmount) internal {
-        // this calculation is based on the assumption that the DS token has 18 decimals but pa can have different decimals
-        dsAmount = TransferHelper.fixedToTokenNativeDecimals(dsAmount, ds);
-        paAmount = TransferHelper.fixedToTokenNativeDecimals(paAmount, pa);
-
         permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(dsAmount), address(ds));
         permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(paAmount), address(pa));
 

--- a/contracts/core/assets/ProtectedUnit.sol
+++ b/contracts/core/assets/ProtectedUnit.sol
@@ -489,10 +489,10 @@ contract ProtectedUnit is
         dsAmount = TransferHelper.fixedToTokenNativeDecimals(dsAmount, ds);
         paAmount = TransferHelper.fixedToTokenNativeDecimals(paAmount, pa);
 
-        permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(amount), address(ds));
-        permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(dsAmount), address(pa));
+        permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(dsAmount), address(ds));
+        permit2.transferFrom(msg.sender, address(this), SafeCast.toUint160(paAmount), address(pa));
 
-        dsHistory[dsIndexMap[address(ds)]].totalDeposited += amount;
+        dsHistory[dsIndexMap[address(ds)]].totalDeposited += dsAmount;
 
         _mint(msg.sender, amount);
 

--- a/test/forge/integration/protectedUnit/ProtectedUnit.t.sol
+++ b/test/forge/integration/protectedUnit/ProtectedUnit.t.sol
@@ -102,6 +102,14 @@ contract ProtectedUnitTest is Helper {
     function test_MintingTokens() public {
         // Test_ minting by the user
         vm.startPrank(user);
+        assertEq(protectedUnit.balanceOf(user), 0);
+        assertEq(protectedUnit.totalSupply(), 0);
+        assertEq(dsToken.balanceOf(address(protectedUnit)), 0);
+        assertEq(pa.balanceOf(address(protectedUnit)), 0);
+
+        uint256 dsBalanceBefore = dsToken.balanceOf(user);
+        uint256 paBalanceBefore = pa.balanceOf(user);
+
         pa.approve(permit2, USER_BALANCE);
         dsToken.approve(permit2, USER_BALANCE);
 
@@ -124,6 +132,10 @@ contract ProtectedUnitTest is Helper {
         // Check token balances in the contract
         assertEq(dsToken.balanceOf(address(protectedUnit)), mintAmount);
         assertEq(pa.balanceOf(address(protectedUnit)), mintAmount);
+
+        // Check user token balances decreased correctly
+        assertEq(dsToken.balanceOf(user), dsBalanceBefore - mintAmount);
+        assertEq(pa.balanceOf(user), paBalanceBefore - mintAmount);
 
         vm.stopPrank();
     }
@@ -184,6 +196,11 @@ contract ProtectedUnitTest is Helper {
         uint256 startBalanceDS = dsToken.balanceOf(user);
         uint256 startBalancePA = pa.balanceOf(user);
         uint256 startBalancePU = protectedUnit.balanceOf(user);
+
+        assertEq(startBalancePU, 0);
+        assertEq(protectedUnit.totalSupply(), 0);
+        assertEq(dsToken.balanceOf(address(protectedUnit)), 0);
+        assertEq(pa.balanceOf(address(protectedUnit)), 0);
 
         // Call the mint function with Permit2 data
         (uint256 actualDsAmount, uint256 actualPaAmount) = protectedUnit.mint(mintAmount, permitBatchData, signature);

--- a/test/forge/integration/protectedUnit/ProtectedUnit.t.sol
+++ b/test/forge/integration/protectedUnit/ProtectedUnit.t.sol
@@ -137,6 +137,11 @@ contract ProtectedUnitTest is Helper {
         assertEq(dsToken.balanceOf(user), dsBalanceBefore - mintAmount);
         assertEq(pa.balanceOf(user), paBalanceBefore - mintAmount);
 
+        (address dsAddress, uint256 totalDeposited) =
+            protectedUnit.dsHistory(protectedUnit.dsIndexMap(address(dsToken)));
+        assertEq(dsAddress, address(dsToken));
+        assertEq(totalDeposited, mintAmount);
+
         vm.stopPrank();
     }
 
@@ -221,6 +226,10 @@ contract ProtectedUnitTest is Helper {
         assertEq(dsToken.balanceOf(address(protectedUnit)), dsAmount);
         assertEq(pa.balanceOf(address(protectedUnit)), paAmount);
 
+        (address dsAddress, uint256 totalDeposited) =
+            protectedUnit.dsHistory(protectedUnit.dsIndexMap(address(dsToken)));
+        assertEq(dsAddress, address(dsToken));
+        assertEq(totalDeposited, mintAmount);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
# Changes

List of Changes:
 - use correct variables when transferring token from user when minting in protected unit
 - remove redundant token decimals conversion

