### PR TITLE
Protected Unit partial deregister

### DIFF
--- a/contracts/core/assets/ProtectedUnitFactory.sol
+++ b/contracts/core/assets/ProtectedUnitFactory.sol
@@ -201,6 +201,13 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
      * @custom:reverts NotConfig if caller is not the CONFIG address
      */
     function deRegisterProtectedUnit(Id _id) external onlyConfig {
+        ProtectedUnit pu = ProtectedUnit(protectedUnitContracts[_id]);
+
+        if (address(pu) == address(0)) revert InvalidParam();
+
+        address ra = pu.ra();
+        address pa = pu.pa();
+
         delete protectedUnitContracts[_id];
 
         uint256 index = protectedUnitIndex[_id];
@@ -210,6 +217,8 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
         // for some reason the compiler won't let us delete a user defined types
         // so we just set it to default value
         protectedUnits[index] = Id.wrap(bytes32(""));
+
+        emit ProtectedUnitDeregistered(_id, pa, ra, address(pu));
     }
 
     /**

--- a/contracts/core/assets/ProtectedUnitFactory.sol
+++ b/contracts/core/assets/ProtectedUnitFactory.sol
@@ -204,7 +204,7 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
         delete protectedUnitContracts[_id];
 
         uint256 index = protectedUnitIndex[_id];
-        
+
         delete protectedUnitIndex[_id];
 
         // for some reason the compiler won't let us delete a user defined types

--- a/contracts/core/assets/ProtectedUnitFactory.sol
+++ b/contracts/core/assets/ProtectedUnitFactory.sol
@@ -39,6 +39,8 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
      */
     mapping(Id => address) public protectedUnitContracts;
 
+    mapping(Id => uint256) public protectedUnitIndex;
+
     /**
      * @notice Mapping of indices to pair IDs for deployed Protected Units
      * @dev Used for pagination in getDeployedProtectedUnits function
@@ -173,8 +175,11 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
         // Store the address of the new protected unit proxy contract
         protectedUnitContracts[_id] = newUnit;
 
+        uint256 index = ++idx;
+
         // solhint-disable-next-line gas-increment-by-one
-        protectedUnits[idx++] = _id;
+        protectedUnits[index] = _id;
+        protectedUnitIndex[_id] = index;
 
         emit ProtectedUnitDeployed(_id, _pa, _ra, newUnit);
     }
@@ -197,6 +202,14 @@ contract ProtectedUnitFactory is IProtectedUnitFactory, OwnableUpgradeable, UUPS
      */
     function deRegisterProtectedUnit(Id _id) external onlyConfig {
         delete protectedUnitContracts[_id];
+
+        uint256 index = protectedUnitIndex[_id];
+        
+        delete protectedUnitIndex[_id];
+
+        // for some reason the compiler won't let us delete a user defined types
+        // so we just set it to default value
+        protectedUnits[index] = Id.wrap(bytes32(""));
     }
 
     /**

--- a/contracts/interfaces/IProtectedUnit.sol
+++ b/contracts/interfaces/IProtectedUnit.sol
@@ -51,6 +51,18 @@ interface IProtectedUnit is IErrors {
      */
     function mintCap() external view returns (uint256);
 
+    function pa() external view returns (address);
+
+    function ra() external view returns (address);
+
+    function dsReserve() external view returns (uint256);
+
+    function paReserve() external view returns (uint256);
+
+    function raReserve() external view returns (uint256);
+
+    function latestDs() external view returns (address);
+
     /**
      * @notice Calculates how many DS and PA tokens you need to create Protected Unit tokens
      * @param amount How many Protected Unit tokens you want to create

--- a/contracts/interfaces/IProtectedUnitFactory.sol
+++ b/contracts/interfaces/IProtectedUnitFactory.sol
@@ -27,7 +27,13 @@ interface IProtectedUnitFactory is IErrors {
      * @param ra Address of the Return Asset (RA) token
      * @param protectedUnitAddress Address of the newly created Protected Unit contract
      */
-    event ProtectedUnitDeployed(Id indexed pairId, address pa, address ra, address indexed protectedUnitAddress);
+    event ProtectedUnitDeployed(
+        Id indexed pairId, address indexed pa, address indexed ra, address protectedUnitAddress
+    );
+
+    event ProtectedUnitDeregistered(
+        Id indexed pairId, address indexed pa, address indexed ra, address protectedUnitAddress
+    );
 
     /**
      * @notice Creates a new Protected Unit contract


### PR DESCRIPTION
# Changes

List of Changes:
 - completely wipe out reference data associated to a PU id when deregistering protected unit
 - add proper event when deregistering
 - added check for non-existent id

