### PR TITLE
Add configNotPaused check and related error handling

### DIFF
--- a/contracts/core/ModuleCore.sol
+++ b/contracts/core/ModuleCore.sol
@@ -101,6 +101,8 @@ contract ModuleCore is OwnableUpgradeable, UUPSUpgradeable, PsmCore, Initialize,
         address exchangeRateProvider
     ) external override {
         onlyConfig();
+        configNotPaused();
+
         if (expiryInterval == 0) {
             revert InvalidExpiry();
         }

--- a/contracts/core/ModuleState.sol
+++ b/contracts/core/ModuleState.sol
@@ -144,4 +144,11 @@ abstract contract ModuleState is IErrors, ReentrancyGuardTransient, Extsload {
             revert DeadlineExceeded();
         }
     }
+
+    // @notice checks if config contract is paused or not
+    function configNotPaused() internal view {
+        if (CorkConfig(CONFIG).paused()) {
+            revert ConfigPaused();
+        }
+    }
 }

--- a/contracts/interfaces/IErrors.sol
+++ b/contracts/interfaces/IErrors.sol
@@ -122,6 +122,9 @@ interface IErrors {
     /// @notice LV Withdrawal is paused, i.e thrown when withdrawal is paused for LV
     error LVWithdrawalPaused();
 
+    /// @notice Config is paused, i.e thrown when config is paused
+    error ConfigPaused();
+
     /// @notice When transaction is mutex locked for ensuring non-reentrancy
     error StateLocked();
 

--- a/test/forge/unit/Asset.t.sol
+++ b/test/forge/unit/Asset.t.sol
@@ -4,6 +4,7 @@ import "./../Helper.sol";
 import "./../../../contracts/dummy/DummyWETH.sol";
 import "./../../../contracts/core/assets/Asset.sol";
 import "./../../../contracts/libraries/Pair.sol";
+import {IErrors} from "./../../../contracts/interfaces/IErrors.sol";
 
 contract AssetTest is Helper {
     DummyWETH ra;
@@ -88,5 +89,14 @@ contract AssetTest is Helper {
         assertReserve(ct, redeemAmount, redeemAmount);
         assertReserve(ds, redeemAmount, redeemAmount);
         assertReserve(lv, redeemAmount, redeemAmount);
+    }
+
+    function test_initializeModuleCoreRevertWhenConfigIsPaused() external {
+        vm.startPrank(DEFAULT_ADDRESS);
+        corkConfig.pause();
+        assertTrue(corkConfig.paused());
+
+        vm.expectRevert(IErrors.ConfigPaused.selector);
+        corkConfig.initializeModuleCore(address(0), address(0), 0, 0, address(0));
     }
 }


### PR DESCRIPTION
# Changes

List of Changes:
- [x] Introduced configNotPaused function to verify if the configuration contract is paused.
- [x] Updated ModuleCore to call configNotPaused during initialization.
- [x] Added ConfigPaused error to IErrors interface.
- [x] Implemented a test case to ensure proper reversion when the config is paused.